### PR TITLE
Simplify-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,6 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "requests>=2.31.0",
-    "tqdm>=4.66.1",
-    "jsonschema>=4.20.0",
-    "tenacity>=8.2.0",
-    "torch>=2.1.0",
-    "numpy>=1.24.0",
     "pandas>=2.1.0",
     "pyyaml>=6.0.1",
     "python-dotenv>=1.0.1",


### PR DESCRIPTION
Remove 5 unused dependencies that are not used in the aiflux CLI tool:
- tqdm: No progress bars used in code
- jsonschema: Using Pydantic instead for validation
- tenacity: No retry logic using this library
- torch: Only needed in containers, not in CLI tool
- numpy: Not used anywhere in aiflux code