### PR TITLE
feat: add model field to JSONL output for OpenAI batch API compatibility

### DIFF
--- a/src/llmflux/benchmark_utils.py
+++ b/src/llmflux/benchmark_utils.py
@@ -103,7 +103,7 @@ def extract_prompts_from_jsonl(
 
     return prompts[:num_prompts]
 
-def create_test_prompts_file(num_prompts: int = 120, temperature: float = 0.7, max_tokens: int = 500) -> str:
+def create_test_prompts_file(num_prompts: int = 120, temperature: float = 0.7, max_tokens: int = 500, model: str = None) -> str:
     """Get test prompts for a given model from 6 LiveBench categories: data_analysis, language, math, reasoning, instruction_following, and coding.
     Args:
         num_prompts: Total number of prompts to generate.
@@ -126,7 +126,7 @@ def create_test_prompts_file(num_prompts: int = 120, temperature: float = 0.7, m
         file_name = benchmark_dir / f"{file_names[i]}.jsonl"
         prompts = extract_prompts_from_jsonl(file_name, num_prompts=num_prompts//len(file_names))
         for prompt in prompts:
-            all_prompts.append({"custom_id":"request1","method":"POST","url":"/v1/chat/completions","body":{"messages":prompt,"temperature":temperature,"max_tokens":max_tokens}})
+            all_prompts.append({"custom_id":"request1","method":"POST","url":"/v1/chat/completions","body":{"model":model,"messages":prompt,"temperature":temperature,"max_tokens":max_tokens}})
     save_prompts_to_jsonl(all_prompts, prompts_file)
 
     return str(prompts_file)

--- a/src/llmflux/cli.py
+++ b/src/llmflux/cli.py
@@ -113,7 +113,7 @@ def _benchmark_command(args: argparse.Namespace) -> int:
         temperature = 0.7 if args.temperature is None else args.temperature
         max_tokens = 500 if args.max_tokens is None else args.max_tokens
 
-        input_path = create_test_prompts_file(num_prompts=num_prompts, temperature=temperature, max_tokens=max_tokens)
+        input_path = create_test_prompts_file(num_prompts=num_prompts, temperature=temperature, max_tokens=max_tokens, model=args.model)
         
     # Set output path
     if args.output:

--- a/src/llmflux/converters/json.py
+++ b/src/llmflux/converters/json.py
@@ -182,13 +182,17 @@ def _process_json_item(
                 item['custom_id'] = str(item[id_field])
             else:
                 item['custom_id'] = generate_custom_id()
-        
+
+        # Inject model into body if provided and not already set
+        if model and 'model' not in item['body']:
+            item['body']['model'] = model
+
         # Add API parameters if provided
         if api_parameters and 'body' in item:
             for key, value in api_parameters.items():
                 if key not in item['body']:
                     item['body'][key] = value
-                
+
         # Write item as is
         file_handle.write(json.dumps(item) + '\n')
         return

--- a/src/llmflux/processors/batch.py
+++ b/src/llmflux/processors/batch.py
@@ -59,6 +59,18 @@ class BatchProcessor:
         
         # Ensure temp directory exists
         os.makedirs(self.temp_dir, exist_ok=True)
+
+    def _get_validated_model(self, body: Dict[str, Any]) -> str:
+        """Return request model after validating against configured model."""
+        requested_model = self.model_config.get_model_name_for_engine()
+        jsonl_model = body.get('model')
+
+        if jsonl_model and jsonl_model != requested_model:
+            raise ValueError(
+                f"JSONL model '{jsonl_model}' does not match requested model '{requested_model}'"
+            )
+
+        return jsonl_model or requested_model
     
     def setup(self, engine: str = "ollama"):
         """Initialize LLM client and warm up model."""
@@ -162,8 +174,7 @@ class BatchProcessor:
             Chat completion response
         """
         messages = body.get('messages', [])
-        # Use the engine-appropriate model name
-        model = body.get('model', self.model_config.get_model_name_for_engine())
+        model = self._get_validated_model(body)
         
         # Extract parameters with defaults from model config
         temperature = body.get('temperature', self.model_config.parameters.temperature)
@@ -211,7 +222,7 @@ class BatchProcessor:
             Completion response
         """
         prompt = body.get('prompt', '')
-        model = body.get('model', self.model_config.get_model_name_for_engine())
+        model = self._get_validated_model(body)
 
         # Extract parameters with defaults from model config
         temperature = body.get('temperature', self.model_config.parameters.temperature)

--- a/tests/processors/test_batch.py
+++ b/tests/processors/test_batch.py
@@ -137,6 +137,66 @@ class TestBatchProcessor(unittest.TestCase):
             top_p=0.9,
             stop=None
         )
+
+    @patch('llmflux.processors.batch.LLMClient')
+    def test_process_batch_accepts_matching_jsonl_model(self, mock_client_class):
+        """Model in JSONL body is accepted when it matches requested llmflux model."""
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "This is a test response."
+        mock_client_class.return_value = mock_client
+
+        matching_entry = {
+            "custom_id": "test-match-model",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {
+                "model": "test/test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        }
+
+        processor = BatchProcessor(model_config=self.model_config)
+        processor.setup()
+        results = processor.process_batch("vllm", [matching_entry])
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].error)
+        mock_client.chat.assert_any_call(
+            model="test/test-model",
+            engine="vllm",
+            messages=matching_entry["body"]["messages"],
+            temperature=0.7,
+            max_tokens=500,
+            top_p=0.9,
+            stop=None,
+        )
+
+    @patch('llmflux.processors.batch.LLMClient')
+    def test_process_batch_rejects_mismatched_jsonl_model(self, mock_client_class):
+        """Model mismatch between JSONL body and requested llmflux model returns error."""
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "This is a test response."
+        mock_client_class.return_value = mock_client
+
+        mismatch_entry = {
+            "custom_id": "test-mismatch-model",
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {
+                "model": "different/model",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        }
+
+        processor = BatchProcessor(model_config=self.model_config)
+        processor.setup()
+        results = processor.process_batch("vllm", [mismatch_entry])
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].output)
+        self.assertIn("does not match requested model", results[0].error)
+        self.assertTrue(results[0].metadata.get("error"))
+        mock_client.chat.assert_called_once()  # setup() warmup only
     
     @patch('llmflux.processors.batch.LLMClient')
     def test_run_with_jsonl(self, mock_client_class):

--- a/tests/test_benchmark_utils.py
+++ b/tests/test_benchmark_utils.py
@@ -157,7 +157,7 @@ class TestCreateTestPromptsFile(unittest.TestCase):
         for cat in categories:
             self._write_category_file(bench_dir, cat, n=5)
         with patch.object(bu, "BENCHMARK_DATA_DIR", bench_dir):
-            result_path = create_test_prompts_file(num_prompts=6)
+            result_path = create_test_prompts_file(num_prompts=6, model="test-model")
         with open(result_path) as f:
             lines = [json.loads(l) for l in f if l.strip()]
         self.assertGreater(len(lines), 0)
@@ -166,6 +166,7 @@ class TestCreateTestPromptsFile(unittest.TestCase):
             self.assertIn("method", entry)
             self.assertIn("body", entry)
             self.assertIn("messages", entry["body"])
+            self.assertIn("model", entry["body"])
 
     def test_calls_download_when_files_missing(self):
         import llmflux.benchmark_utils as bu

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -402,7 +402,7 @@ class TestBenchmarkCommand:
 
         # Verify
         assert result == 0
-        mock_create_prompts.assert_called_once_with(num_prompts=50, temperature=0.7, max_tokens=500)
+        mock_create_prompts.assert_called_once_with(num_prompts=50, temperature=0.7, max_tokens=500, model="Llama-3.2-3B-Instruct")
         mock_runner.run.assert_called_once()
     
     @patch('llmflux.cli._wait_for_slurm_elapsed_seconds', return_value=None)
@@ -1248,7 +1248,7 @@ class TestCommandLineIntegration:
                 result = main()
 
         assert result == 0
-        mock_create_prompts.assert_called_once_with(num_prompts=100, temperature=0.7, max_tokens=500)
+        mock_create_prompts.assert_called_once_with(num_prompts=100, temperature=0.7, max_tokens=500, model="Llama-3.2-3B-Instruct")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Include model in body of all generated JSONL entries so requests are valid per the OpenAI batch API spec. Pass args.model through to create_test_prompts_file, and inject model into pre-formatted batch entries that lack it in _process_json_item.