### PR TITLE
Update tests

### DIFF
--- a/src/llmflux/slurm/runner.py
+++ b/src/llmflux/slurm/runner.py
@@ -605,6 +605,10 @@ class SlurmRunner:
             env_args = self._load_vllm_engine_args(os.getenv("VLLM_ENGINE_ARGS"), "VLLM_ENGINE_ARGS")
             cli_args = self._load_vllm_engine_args(kwargs.get("vllm_engine_args"), "--vllm-engine-args")
             merged_args = {**env_args, **cli_args}
+            # Automatically set tensor parallelism when multiple GPUs are requested,
+            # unless the user has already specified it.
+            if self.slurm_config.gpus_per_node > 1 and "tensor-parallel-size" not in merged_args:
+                merged_args["tensor-parallel-size"] = self.slurm_config.gpus_per_node
             env['VLLM_ENGINE_ARGS'] = self._build_vllm_engine_args(merged_args)
 
         env['APPTAINERENV_MODEL_IDENTIFIER'] = str(model_identifier)

--- a/tests/converters/test_json.py
+++ b/tests/converters/test_json.py
@@ -228,5 +228,175 @@ class TestJSONToJSONL(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertEqual(result["error"], "Key 'nonexistent_key' not found in JSON")
 
+    def test_auto_output_path(self):
+        """No output_path → temp file is created and populated."""
+        result = json_to_jsonl(self.simple_array_json)
+        self.assertTrue(result["success"])
+        self.assertIsNotNone(result["output_path"])
+        self.assertTrue(os.path.exists(result["output_path"]))
+        with open(result["output_path"]) as f:
+            lines = [l for l in f if l.strip()]
+        self.assertEqual(len(lines), 3)
+
+    def test_invalid_json_file(self):
+        """Malformed JSON file returns success=False with an error message."""
+        bad_json = self.test_dir / "bad.json"
+        bad_json.write_text("{not valid json}")
+        result = json_to_jsonl(bad_json, self.output_path)
+        self.assertFalse(result["success"])
+        self.assertIn("JSON decode error", result["error"])
+
+    def test_unsupported_root_type(self):
+        """A JSON file whose root is a string/number returns success=False."""
+        string_root = self.test_dir / "string_root.json"
+        string_root.write_text('"just a string"')
+        result = json_to_jsonl(string_root, self.output_path)
+        self.assertFalse(result["success"])
+        self.assertIn("Unsupported JSON format", result["error"])
+
+    def test_failed_item_increments_counter(self):
+        """An item that raises during processing increments failed_conversions."""
+        from unittest.mock import patch
+        array_json = self.test_dir / "arr.json"
+        array_json.write_text('[{"id": 1}, {"id": 2}, {"id": 3}]')
+        with patch("llmflux.converters.json._process_json_item", side_effect=[None, RuntimeError("boom"), None]):
+            result = json_to_jsonl(array_json, self.output_path)
+        self.assertEqual(result["failed_conversions"], 1)
+        self.assertEqual(result["successful_conversions"], 2)
+
+    def test_batch_format_generates_custom_id(self):
+        """Item already in batch format without custom_id gets one generated."""
+        data = [{"method": "POST", "url": "/v1/chat/completions", "body": {"messages": []}}]
+        input_path = self.test_dir / "batch_no_id.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path)
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        self.assertIn("custom_id", entry)
+        self.assertTrue(entry["custom_id"])
+
+    def test_batch_format_uses_id_field(self):
+        """Item in batch format uses id_field as custom_id when present."""
+        data = [{"method": "POST", "url": "/v1/chat/completions", "body": {}, "my_id": "req-42"}]
+        input_path = self.test_dir / "batch_id_field.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path, id_field="my_id")
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        self.assertEqual(entry["custom_id"], "req-42")
+
+    def test_batch_format_preserves_existing_model(self):
+        """A model already in body is not removed or altered."""
+        data = [{"method": "POST", "url": "/v1/chat/completions", "body": {"model": "original"}}]
+        input_path = self.test_dir / "batch_has_model.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path)
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        self.assertEqual(entry["body"]["model"], "original")
+
+    def test_batch_format_merges_api_parameters(self):
+        """api_parameters are merged into body when keys not already set."""
+        data = [{"method": "POST", "url": "/v1/chat/completions", "body": {"messages": []}}]
+        input_path = self.test_dir / "batch_api_params.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path, api_parameters={"top_p": 0.9})
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        self.assertEqual(entry["body"]["top_p"], 0.9)
+
+    def test_messages_format_with_id_field(self):
+        """Item with messages key uses id_field for custom_id."""
+        data = [{"messages": [{"role": "user", "content": "hi"}], "req_id": "msg-7"}]
+        input_path = self.test_dir / "messages_id.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path, id_field="req_id")
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        self.assertEqual(entry["custom_id"], "msg-7")
+
+    def test_messages_format_with_prompt_template(self):
+        """prompt_template wraps user message content."""
+        data = [{"messages": [{"role": "user", "content": "cats"}]}]
+        input_path = self.test_dir / "messages_tmpl.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path, prompt_template="Tell me about: {content}")
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        user_msg = next(m for m in entry["body"]["messages"] if m["role"] == "user")
+        self.assertEqual(user_msg["content"], "Tell me about: cats")
+
+    def test_prompt_format_with_system_key(self):
+        """Item with prompt + system keys produces a system message first."""
+        data = [{"prompt": "Hello", "system": "You are helpful."}]
+        input_path = self.test_dir / "prompt_system.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path)
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        messages = entry["body"]["messages"]
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertEqual(messages[0]["content"], "You are helpful.")
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertEqual(messages[1]["content"], "Hello")
+
+    def test_prompt_format_with_template(self):
+        """prompt_template is applied to the prompt value."""
+        data = [{"prompt": "dogs"}]
+        input_path = self.test_dir / "prompt_tmpl.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path, prompt_template="Describe: {content}")
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        user_msg = next(m for m in entry["body"]["messages"] if m["role"] == "user")
+        self.assertEqual(user_msg["content"], "Describe: dogs")
+
+    def test_prompt_format_with_id_field(self):
+        """Item with prompt key uses id_field for custom_id."""
+        data = [{"prompt": "hi", "task_id": "t-99"}]
+        input_path = self.test_dir / "prompt_id.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path, id_field="task_id")
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        self.assertEqual(entry["custom_id"], "t-99")
+
+    def test_generic_dict_no_recognized_keys(self):
+        """Dict with no prompt/messages/batch keys is serialised as user message content."""
+        data = [{"foo": "bar", "baz": 42}]
+        input_path = self.test_dir / "generic.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path)
+        self.assertTrue(result["success"])
+        with open(self.output_path) as f:
+            entry = json.loads(f.readline())
+        content = entry["body"]["messages"][0]["content"]
+        parsed = json.loads(content)
+        self.assertEqual(parsed["foo"], "bar")
+        self.assertIn("original_item", entry["metadata"])
+
+    def test_non_dict_item_string(self):
+        """A JSON array of plain strings produces one entry per string."""
+        data = ["first prompt", "second prompt"]
+        input_path = self.test_dir / "strings.json"
+        input_path.write_text(json.dumps(data))
+        result = json_to_jsonl(input_path, self.output_path)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["successful_conversions"], 2)
+        with open(self.output_path) as f:
+            lines = [json.loads(l) for l in f if l.strip()]
+        self.assertEqual(lines[0]["body"]["messages"][0]["content"], "first prompt")
+        self.assertEqual(lines[1]["body"]["messages"][0]["content"], "second prompt")
+
+
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()

--- a/tests/processors/test_batch.py
+++ b/tests/processors/test_batch.py
@@ -293,5 +293,86 @@ class TestBatchProcessor(unittest.TestCase):
         self.assertEqual(output["object"], "text_completion")
         self.assertEqual(output["choices"][0]["text"], "blue")
 
+    @patch('llmflux.processors.batch.LLMClient')
+    def test_completion_endpoint_rejects_mismatched_model(self, mock_client_class):
+        """_get_validated_model raises on mismatch for /v1/completions requests."""
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "blue"
+        mock_client_class.return_value = mock_client
+
+        completions_jsonl = self.test_dir / "completions_mismatch.jsonl"
+        entry = {
+            "custom_id": "completion-mismatch",
+            "method": "POST",
+            "url": "/v1/completions",
+            "body": {
+                "model": "different/model",
+                "prompt": "Complete this:",
+                "temperature": 0.7,
+                "max_tokens": 100,
+            },
+        }
+        with open(completions_jsonl, "w") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        processor = BatchProcessor(model_config=self.model_config)
+        results = processor.run(completions_jsonl, self.output_path, "vllm")
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].output)
+        self.assertIn("does not match requested model", results[0].error)
+        self.assertTrue(results[0].metadata.get("error"))
+
+    @patch('llmflux.processors.batch.LLMClient')
+    def test_completion_endpoint_accepts_matching_model(self, mock_client_class):
+        """_get_validated_model accepts matching model field on /v1/completions."""
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "blue"
+        mock_client_class.return_value = mock_client
+
+        completions_jsonl = self.test_dir / "completions_match.jsonl"
+        entry = {
+            "custom_id": "completion-match",
+            "method": "POST",
+            "url": "/v1/completions",
+            "body": {
+                "model": "test/test-model",
+                "prompt": "Complete this:",
+                "temperature": 0.7,
+                "max_tokens": 100,
+            },
+        }
+        with open(completions_jsonl, "w") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        processor = BatchProcessor(model_config=self.model_config)
+        results = processor.run(completions_jsonl, self.output_path, "vllm")
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(results[0].error)
+        self.assertIsNotNone(results[0].output)
+
+    @patch('llmflux.processors.batch.LLMClient')
+    def test_get_validated_model_no_model_field_uses_config(self, mock_client_class):
+        """_get_validated_model returns the config model name when body has no model key."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        processor = BatchProcessor(model_config=self.model_config)
+        result = processor._get_validated_model({})
+        self.assertEqual(result, "test/test-model")
+
+    @patch('llmflux.processors.batch.LLMClient')
+    def test_get_validated_model_mismatch_raises(self, mock_client_class):
+        """_get_validated_model raises ValueError when model field doesn't match config."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        processor = BatchProcessor(model_config=self.model_config)
+        with self.assertRaises(ValueError) as ctx:
+            processor._get_validated_model({"model": "wrong/model"})
+        self.assertIn("does not match requested model", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main() 

--- a/tests/processors/test_batch.py
+++ b/tests/processors/test_batch.py
@@ -327,7 +327,9 @@ class TestBatchProcessor(unittest.TestCase):
     def test_completion_endpoint_accepts_matching_model(self, mock_client_class):
         """_get_validated_model accepts matching model field on /v1/completions."""
         mock_client = MagicMock()
-        mock_client.chat.return_value = "blue"
+        # Tuple form matches the (content, usage) contract client.chat() returns
+        # with return_usage=True, used once benchmarking's batch.py changes land.
+        mock_client.chat.return_value = ("blue", {})
         mock_client_class.return_value = mock_client
 
         completions_jsonl = self.test_dir / "completions_match.jsonl"

--- a/tests/slurm/test_commands.py
+++ b/tests/slurm/test_commands.py
@@ -4,6 +4,9 @@ from unittest.mock import patch
 
 from llmflux.slurm.commands import (
     SlurmCommandError,
+    _extract_jobs,
+    _parse_state_value,
+    _run_json_command,
     cancel_job,
     extract_state,
     get_active_job_details,
@@ -59,3 +62,98 @@ class TestSlurmCommands(unittest.TestCase):
             extract_state({"state": {"current": ["COMPLETED"], "reason": "None"}}),
             "COMPLETED",
         )
+
+    def test_extract_state_no_known_key(self):
+        self.assertEqual(extract_state({}), "UNKNOWN")
+
+
+class TestRunJsonCommand(unittest.TestCase):
+    @patch("llmflux.slurm.commands.subprocess.run")
+    def test_raises_on_nonzero_returncode(self, mock_run):
+        mock_run.return_value = _completed("", returncode=1, stderr="oops")
+        with self.assertRaises(SlurmCommandError):
+            _run_json_command(["sacct", "--json"])
+
+    @patch("llmflux.slurm.commands.subprocess.run")
+    def test_empty_stdout_returns_empty_dict(self, mock_run):
+        mock_run.return_value = _completed("")
+        result = _run_json_command(["sacct", "--json"])
+        self.assertEqual(result, {})
+
+    @patch("llmflux.slurm.commands.subprocess.run")
+    def test_invalid_json_raises(self, mock_run):
+        mock_run.return_value = _completed("not json at all")
+        with self.assertRaises(SlurmCommandError):
+            _run_json_command(["sacct", "--json"])
+
+    @patch("llmflux.slurm.commands.subprocess.run")
+    def test_valid_json_returned(self, mock_run):
+        mock_run.return_value = _completed('{"jobs": []}')
+        result = _run_json_command(["sacct", "--json"])
+        self.assertEqual(result, {"jobs": []})
+
+
+class TestExtractJobs(unittest.TestCase):
+    def test_non_dict_payload_returns_empty(self):
+        self.assertEqual(_extract_jobs([]), [])
+        self.assertEqual(_extract_jobs("string"), [])
+        self.assertEqual(_extract_jobs(None), [])
+
+    def test_jobs_not_a_list_returns_empty(self):
+        self.assertEqual(_extract_jobs({"jobs": "oops"}), [])
+
+    def test_filters_non_dict_entries(self):
+        payload = {"jobs": [{"job_id": 1}, "not-a-dict", {"job_id": 2}]}
+        result = _extract_jobs(payload)
+        self.assertEqual(len(result), 2)
+
+    def test_empty_jobs_list(self):
+        self.assertEqual(_extract_jobs({"jobs": []}), [])
+
+
+class TestParseStateValue(unittest.TestCase):
+    def test_dict_with_current_list(self):
+        self.assertEqual(_parse_state_value({"current": ["RUNNING"]}), "RUNNING")
+
+    def test_dict_with_current_string(self):
+        self.assertEqual(_parse_state_value({"current": "pending"}), "PENDING")
+
+    def test_dict_with_CURRENT_uppercase_key(self):
+        self.assertEqual(_parse_state_value({"CURRENT": ["FAILED"]}), "FAILED")
+
+    def test_dict_with_empty_current_list(self):
+        self.assertIsNone(_parse_state_value({"current": []}))
+
+    def test_dict_missing_current_key(self):
+        self.assertIsNone(_parse_state_value({"reason": "None"}))
+
+    def test_list_single_element(self):
+        self.assertEqual(_parse_state_value(["COMPLETED"]), "COMPLETED")
+
+    def test_list_empty(self):
+        self.assertIsNone(_parse_state_value([]))
+
+    def test_plain_string(self):
+        self.assertEqual(_parse_state_value("running"), "RUNNING")
+
+    def test_blank_string(self):
+        self.assertIsNone(_parse_state_value("   "))
+
+    def test_none_input(self):
+        self.assertIsNone(_parse_state_value(None))
+
+
+class TestCancelJob(unittest.TestCase):
+    @patch("llmflux.slurm.commands.subprocess.run")
+    def test_force_flag_adds_signal(self, mock_run):
+        mock_run.return_value = _completed("", returncode=0)
+        cancel_job("123", force=True)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--signal=KILL", cmd)
+
+    @patch("llmflux.slurm.commands.subprocess.run")
+    def test_no_force_omits_signal(self, mock_run):
+        mock_run.return_value = _completed("", returncode=0)
+        cancel_job("123", force=False)
+        cmd = mock_run.call_args[0][0]
+        self.assertNotIn("--signal=KILL", cmd)

--- a/tests/slurm/test_runner.py
+++ b/tests/slurm/test_runner.py
@@ -437,6 +437,110 @@ class TestSlurmRunnerServe(unittest.TestCase):
         result = runner.serve(email="user@example.com", model="test:7b")
 
         self.assertIsNone(result)
+class TestLoadVllmEngineArgs(unittest.TestCase):
+    def _make_runner(self):
+        with patch("llmflux.slurm.runner.ConfigManager") as mock_cm:
+            mock_cm.return_value.get_config.return_value = MagicMock()
+            return SlurmRunner()
+
+    def test_none_returns_empty(self):
+        runner = self._make_runner()
+        self.assertEqual(runner._load_vllm_engine_args(None, "test"), {})
+
+    def test_dict_returned_as_is(self):
+        runner = self._make_runner()
+        d = {"max_model_len": 4096}
+        self.assertEqual(runner._load_vllm_engine_args(d, "test"), d)
+
+    def test_empty_string_returns_empty(self):
+        runner = self._make_runner()
+        self.assertEqual(runner._load_vllm_engine_args("", "test"), {})
+        self.assertEqual(runner._load_vllm_engine_args("   ", "test"), {})
+
+    def test_valid_json_object_string(self):
+        runner = self._make_runner()
+        result = runner._load_vllm_engine_args('{"max_model_len": 4096}', "test")
+        self.assertEqual(result, {"max_model_len": 4096})
+
+    def test_invalid_json_string_returns_empty(self):
+        runner = self._make_runner()
+        self.assertEqual(runner._load_vllm_engine_args("{bad json}", "test"), {})
+
+    def test_json_array_returns_empty(self):
+        runner = self._make_runner()
+        self.assertEqual(runner._load_vllm_engine_args("[1, 2, 3]", "test"), {})
+
+    def test_non_string_non_dict_returns_empty(self):
+        runner = self._make_runner()
+        self.assertEqual(runner._load_vllm_engine_args(42, "test"), {})
+        self.assertEqual(runner._load_vllm_engine_args(["a"], "test"), {})
+
+
+class TestBuildVllmEngineArgs(unittest.TestCase):
+    def _make_runner(self):
+        with patch("llmflux.slurm.runner.ConfigManager") as mock_cm:
+            mock_cm.return_value.get_config.return_value = MagicMock()
+            return SlurmRunner()
+
+    def test_bool_true_emits_flag_only(self):
+        runner = self._make_runner()
+        result = runner._build_vllm_engine_args({"enable-prefix-caching": True})
+        self.assertIn("--enable-prefix-caching", result)
+        # No value after the flag
+        parts = result.split()
+        idx = parts.index("--enable-prefix-caching")
+        self.assertEqual(idx, len(parts) - 1)
+
+    def test_bool_false_omits_flag(self):
+        runner = self._make_runner()
+        result = runner._build_vllm_engine_args({"enable-prefix-caching": False})
+        self.assertNotIn("enable-prefix-caching", result)
+
+    def test_none_value_omits_key(self):
+        runner = self._make_runner()
+        result = runner._build_vllm_engine_args({"max_model_len": None})
+        self.assertEqual(result.strip(), "")
+
+    def test_int_value(self):
+        runner = self._make_runner()
+        result = runner._build_vllm_engine_args({"max_model_len": 4096})
+        self.assertIn("--max_model_len", result)
+        self.assertIn("4096", result)
+
+    def test_key_already_prefixed(self):
+        runner = self._make_runner()
+        result = runner._build_vllm_engine_args({"--max_model_len": 512})
+        parts = result.split()
+        flags = [p for p in parts if p.startswith("--")]
+        # Should appear exactly once, not doubled
+        self.assertEqual(flags.count("--max_model_len"), 1)
+
+    def test_unsupported_type_omitted(self):
+        runner = self._make_runner()
+        result = runner._build_vllm_engine_args({"bad_arg": [1, 2, 3]})
+        self.assertEqual(result.strip(), "")
+
+
+class TestBuildJobName(unittest.TestCase):
+    def _make_runner(self):
+        with patch("llmflux.slurm.runner.ConfigManager") as mock_cm:
+            mock_cm.return_value.get_config.return_value = MagicMock()
+            return SlurmRunner()
+
+    def test_special_chars_replaced(self):
+        runner = self._make_runner()
+        name = runner._build_job_name("meta-llama/Llama-3.2-3B")
+        self.assertRegex(name, r"^llmflux_[a-zA-Z0-9_]+_")
+
+    def test_empty_identifier_uses_fallback(self):
+        runner = self._make_runner()
+        name = runner._build_job_name("---")
+        self.assertIn("llmflux_model_", name)
+
+    def test_name_truncated_to_120(self):
+        runner = self._make_runner()
+        name = runner._build_job_name("a" * 200)
+        self.assertLessEqual(len(name), 120)
 
 
 if __name__ == "__main__":

--- a/tests/slurm/test_runner.py
+++ b/tests/slurm/test_runner.py
@@ -166,6 +166,132 @@ class TestSlurmRunner(unittest.TestCase):
         self.assertEqual(job_id, "12345")
 
     @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_run_multi_gpu_auto_sets_tensor_parallel(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """run() with gpus_per_node>1 auto-sets tensor-parallel-size in VLLM_ENGINE_ARGS."""
+        from llmflux.core.config import EngineConfig
+
+        multi_gpu_slurm = SlurmConfig(
+            partition="gpu",
+            nodes=1,
+            ntasks=1,
+            time="01:00:00",
+            mem="64G",
+            ntasks_per_node=1,
+            cpus_per_task=4,
+            gpus_per_node=4,
+            account="project1",
+        )
+        config = Config(
+            data_dir=str(self.data_dir),
+            models_dir=str(self.models_dir),
+            logs_dir=str(self.logs_dir),
+            containers_dir=str(self.containers_dir),
+            slurm=multi_gpu_slurm,
+            models=[self.model_config],
+        )
+        mock_config_manager.return_value.get_config.return_value = config
+        mock_config_manager.return_value.get_parameter.return_value = "4"
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 12345"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=multi_gpu_slurm, engine_config=engine_config)
+        runner.run(
+            input_path=str(self.jsonl_path),
+            output_path=str(self.output_path),
+            model="test:7b",
+        )
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+        self.assertIn("--tensor-parallel-size", env["VLLM_ENGINE_ARGS"])
+        self.assertIn("4", env["VLLM_ENGINE_ARGS"])
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_run_multi_gpu_respects_user_tensor_parallel(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """run() with gpus_per_node>1 does not override user-supplied tensor-parallel-size."""
+        from llmflux.core.config import EngineConfig
+
+        multi_gpu_slurm = SlurmConfig(
+            partition="gpu",
+            nodes=1,
+            ntasks=1,
+            time="01:00:00",
+            mem="64G",
+            ntasks_per_node=1,
+            cpus_per_task=4,
+            gpus_per_node=4,
+            account="project1",
+        )
+        config = Config(
+            data_dir=str(self.data_dir),
+            models_dir=str(self.models_dir),
+            logs_dir=str(self.logs_dir),
+            containers_dir=str(self.containers_dir),
+            slurm=multi_gpu_slurm,
+            models=[self.model_config],
+        )
+        mock_config_manager.return_value.get_config.return_value = config
+        mock_config_manager.return_value.get_parameter.return_value = "4"
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 12345"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=multi_gpu_slurm, engine_config=engine_config)
+        runner.run(
+            input_path=str(self.jsonl_path),
+            output_path=str(self.output_path),
+            model="test:7b",
+            vllm_engine_args={"tensor-parallel-size": 2},
+        )
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+        self.assertIn("--tensor-parallel-size", env["VLLM_ENGINE_ARGS"])
+        self.assertIn("2", env["VLLM_ENGINE_ARGS"])
+        self.assertNotIn("4", env["VLLM_ENGINE_ARGS"])
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_run_single_gpu_no_tensor_parallel(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """run() with gpus_per_node=1 does not inject tensor-parallel-size."""
+        from llmflux.core.config import EngineConfig
+
+        mock_config_manager.return_value.get_config.return_value = self.config
+        mock_config_manager.return_value.get_parameter.return_value = "4"
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 12345"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=self.slurm_config, engine_config=engine_config)
+        runner.run(
+            input_path=str(self.jsonl_path),
+            output_path=str(self.output_path),
+            model="test:7b",
+        )
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+        self.assertNotIn("tensor-parallel-size", env["VLLM_ENGINE_ARGS"])
+
+    @patch("llmflux.slurm.runner.ConfigManager")
     @patch("llmflux.core.config.Config.load_model_config")
     @patch("llmflux.slurm.runner.subprocess.run")
     def test_run_error_handling(self, mock_run, mock_load_model_config, mock_config_manager):
@@ -437,6 +563,147 @@ class TestSlurmRunnerServe(unittest.TestCase):
         result = runner.serve(email="user@example.com", model="test:7b")
 
         self.assertIsNone(result)
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_serve_vllm_sets_engine_env_vars(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """serve() with vllm engine sets VLLM_MODEL_NAME, VLLM_HOST, and VLLM_ENGINE_ARGS."""
+        from llmflux.core.config import EngineConfig
+
+        mock_config_manager.return_value.get_config.return_value = self.config
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 55555"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=self.slurm_config, engine_config=engine_config)
+        runner.serve(email="user@example.com", model="test:7b")
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_MODEL_NAME", env)
+        self.assertEqual(env["VLLM_MODEL_NAME"], "test/test-model")
+        self.assertIn("VLLM_HOST", env)
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_serve_multi_gpu_auto_sets_tensor_parallel(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """serve() with gpus_per_node>1 auto-sets tensor-parallel-size in VLLM_ENGINE_ARGS."""
+        from llmflux.core.config import EngineConfig
+
+        multi_gpu_slurm = SlurmConfig(
+            partition="gpu",
+            nodes=1,
+            ntasks=1,
+            time="02:00:00",
+            mem="128G",
+            ntasks_per_node=1,
+            cpus_per_task=8,
+            gpus_per_node=2,
+            account="project1",
+        )
+        config = Config(
+            data_dir=str(self.test_dir / "data"),
+            models_dir=str(self.test_dir / "models"),
+            logs_dir=str(self.test_dir / "logs"),
+            containers_dir=str(self.test_dir / "containers"),
+            slurm=multi_gpu_slurm,
+            models=[self.model_config],
+        )
+        mock_config_manager.return_value.get_config.return_value = config
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 55555"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=multi_gpu_slurm, engine_config=engine_config)
+        runner.serve(email="user@example.com", model="test:7b")
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+        self.assertIn("--tensor-parallel-size", env["VLLM_ENGINE_ARGS"])
+        self.assertIn("2", env["VLLM_ENGINE_ARGS"])
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_serve_multi_gpu_respects_user_tensor_parallel(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """serve() with gpus_per_node>1 does not override user-supplied tensor-parallel-size."""
+        from llmflux.core.config import EngineConfig
+
+        multi_gpu_slurm = SlurmConfig(
+            partition="gpu",
+            nodes=1,
+            ntasks=1,
+            time="02:00:00",
+            mem="128G",
+            ntasks_per_node=1,
+            cpus_per_task=8,
+            gpus_per_node=4,
+            account="project1",
+        )
+        config = Config(
+            data_dir=str(self.test_dir / "data"),
+            models_dir=str(self.test_dir / "models"),
+            logs_dir=str(self.test_dir / "logs"),
+            containers_dir=str(self.test_dir / "containers"),
+            slurm=multi_gpu_slurm,
+            models=[self.model_config],
+        )
+        mock_config_manager.return_value.get_config.return_value = config
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 55555"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=multi_gpu_slurm, engine_config=engine_config)
+        runner.serve(
+            email="user@example.com",
+            model="test:7b",
+            vllm_engine_args={"tensor-parallel-size": 2},
+        )
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+        self.assertIn("--tensor-parallel-size", env["VLLM_ENGINE_ARGS"])
+        self.assertIn("2", env["VLLM_ENGINE_ARGS"])
+        self.assertNotIn("4", env["VLLM_ENGINE_ARGS"])
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_serve_single_gpu_no_tensor_parallel(
+        self, mock_run, mock_load_model_config, mock_registry, mock_config_manager
+    ):
+        """serve() with gpus_per_node=1 does not inject tensor-parallel-size."""
+        from llmflux.core.config import EngineConfig
+
+        mock_config_manager.return_value.get_config.return_value = self.config
+        mock_load_model_config.return_value = self.model_config
+        mock_run.return_value.stdout = "Submitted batch job 55555"
+
+        engine_config = EngineConfig(engine="vllm", home=str(self.test_dir / ".vllm"))
+        runner = SlurmRunner(config=self.slurm_config, engine_config=engine_config)
+        runner.serve(email="user@example.com", model="test:7b")
+
+        _, call_kwargs = mock_run.call_args
+        env = call_kwargs["env"]
+        self.assertIn("VLLM_ENGINE_ARGS", env)
+        self.assertNotIn("tensor-parallel-size", env["VLLM_ENGINE_ARGS"])
+
+
 class TestLoadVllmEngineArgs(unittest.TestCase):
     def _make_runner(self):
         with patch("llmflux.slurm.runner.ConfigManager") as mock_cm:

--- a/tests/test_benchmark_utils.py
+++ b/tests/test_benchmark_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from llmflux.benchmark_utils import (
     create_test_prompts_file,
+    download_prompts_data,
     ensure_benchmark_data_dir,
     extract_prompts_from_jsonl,
     generate_synthetic_prompts,
@@ -200,6 +201,56 @@ class TestEnsureBenchmarkDataDir(unittest.TestCase):
         result = ensure_benchmark_data_dir()
         self.assertIsInstance(result, Path)
         self.assertTrue(result.exists())
+
+
+class TestDownloadPromptsData(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_raises_import_error_when_deps_missing(self):
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name in ("datasets", "pandas"):
+                raise ImportError(f"No module named '{name}'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            with self.assertRaises(ImportError) as ctx:
+                download_prompts_data()
+        self.assertIn("datasets", str(ctx.exception))
+
+    def test_downloads_all_categories(self):
+        import sys
+        import llmflux.benchmark_utils as bu
+        bench_dir = self.tmp_dir / "benchmark_data"
+        bench_dir.mkdir()
+
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, key: ["What is ML?"] if key == "turns" else None
+
+        mock_df = MagicMock()
+        mock_df.iterrows.return_value = iter([(0, mock_row)])
+
+        mock_dataset = MagicMock()
+        mock_dataset.to_pandas.return_value = mock_df
+
+        mock_datasets_mod = MagicMock()
+        mock_datasets_mod.load_dataset.return_value = mock_dataset
+
+        categories = ["coding", "data_analysis", "instruction_following", "math", "reasoning", "language"]
+
+        with patch.object(bu, "BENCHMARK_DATA_DIR", bench_dir):
+            with patch.dict(sys.modules, {"datasets": mock_datasets_mod}):
+                download_prompts_data()
+
+        written = list(bench_dir.glob("*.jsonl"))
+        self.assertEqual(len(written), len(categories))
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,17 @@ from io import StringIO
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from llmflux.cli import main, _run_command, _benchmark_command, build_parser
+from llmflux.cli import (
+    main,
+    _run_command,
+    _benchmark_command,
+    _get_llmflux_version,
+    _parse_sbatch_args,
+    _render_table,
+    _pick,
+    _show_models_command,
+    build_parser,
+)
 from llmflux.slurm.runner import SlurmRunner
 from llmflux.core.config import Config, SlurmConfig, EngineConfig
 
@@ -1583,6 +1593,113 @@ class TestStatusServeView:
         assert "Output" in output
         assert "Endpoint" not in output
         assert "API Key" not in output
+class TestGetLlmfluxVersion:
+    def test_returns_string_when_installed(self):
+        with patch("llmflux.cli.pkg_version", return_value="1.2.3"):
+            assert _get_llmflux_version() == "1.2.3"
+
+    def test_returns_unknown_when_not_installed(self):
+        from importlib.metadata import PackageNotFoundError
+        with patch("llmflux.cli.pkg_version", side_effect=PackageNotFoundError):
+            assert _get_llmflux_version() == "unknown"
+
+
+class TestParseSbatchArgs:
+    def test_none_returns_none(self):
+        assert _parse_sbatch_args(None) is None
+
+    def test_empty_list_returns_none(self):
+        assert _parse_sbatch_args([]) is None
+
+    def test_valid_pairs_parsed(self):
+        result = _parse_sbatch_args(["account=proj", "partition=gpu"])
+        assert result == {"account": "proj", "partition": "gpu"}
+
+    def test_value_with_equals_sign(self):
+        result = _parse_sbatch_args(["constraint=gpu=a100"])
+        assert result == {"constraint": "gpu=a100"}
+
+    def test_invalid_entry_skipped_with_warning(self, capsys):
+        result = _parse_sbatch_args(["no-equals-here", "key=val"])
+        assert result == {"key": "val"}
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+
+    def test_all_invalid_entries_returns_none(self, capsys):
+        result = _parse_sbatch_args(["no-equals"])
+        assert result is None
+
+
+class TestRenderTable:
+    def test_empty_rows_prints_no_jobs(self, capsys):
+        _render_table([], ["ID", "STATE"])
+        assert "No jobs found." in capsys.readouterr().out
+
+    def test_header_and_rows_printed(self, capsys):
+        _render_table([["123", "RUNNING"]], ["ID", "STATE"])
+        out = capsys.readouterr().out
+        assert "ID" in out
+        assert "STATE" in out
+        assert "123" in out
+        assert "RUNNING" in out
+
+    def test_columns_padded_to_longest_value(self, capsys):
+        _render_table([["1", "COMPLETED"], ["99999", "RUN"]], ["ID", "STATE"])
+        out = capsys.readouterr().out
+        lines = [l for l in out.splitlines() if l.strip()]
+        # Each row should be the same width
+        assert len(lines) == 3  # header + 2 rows
+
+
+class TestPick:
+    def test_returns_first_matching_key(self):
+        assert _pick({"a": "1", "b": "2"}, "a", "b") == "1"
+
+    def test_skips_none_values(self):
+        assert _pick({"a": None, "b": "found"}, "a", "b") == "found"
+
+    def test_skips_blank_string_values(self):
+        assert _pick({"a": "  ", "b": "val"}, "a", "b") == "val"
+
+    def test_returns_dash_dash_when_no_match(self):
+        assert _pick({}, "x", "y") == "--"
+
+    def test_single_key_found(self):
+        assert _pick({"job_id": "42"}, "job_id") == "42"
+
+
+class TestShowModelsCommand:
+    def test_returns_1_when_yaml_missing(self, capsys):
+        args = MagicMock()
+        with patch("llmflux.cli.Path.exists", return_value=False):
+            result = _show_models_command(args)
+        assert result == 1
+
+    def test_returns_0_with_empty_models(self, capsys):
+        args = MagicMock()
+        yaml_content = {"models": {}}
+        with patch("llmflux.cli.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open()):
+                with patch("yaml.safe_load", return_value=yaml_content):
+                    result = _show_models_command(args)
+        assert result == 0
+
+    def test_prints_model_keys(self, capsys):
+        args = MagicMock()
+        yaml_content = {
+            "models": {
+                "llama3": {"name": "llama3:8b", "hf_name": "meta-llama/Llama-3"},
+                "mistral": {"name": "NA", "hf_name": "mistralai/Mistral"},
+            }
+        }
+        with patch("llmflux.cli.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open()):
+                with patch("yaml.safe_load", return_value=yaml_content):
+                    result = _show_models_command(args)
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "llama3" in out
+        assert "mistral" in out
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,7 +40,7 @@ CHAT_ENTRY = {
     "method": "POST",
     "url": "/v1/chat/completions",
     "body": {
-        "model": "test:7b",
+        "model": "test/test-model",
         "messages": [{"role": "user", "content": "Hello"}],
         "temperature": 0.7,
         "max_tokens": 500,
@@ -483,16 +483,17 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
 
     @patch("llmflux.processors.batch.LLMClient")
     def test_model_field_survives_pipeline(self, mock_cls):
-        """model set during json_to_jsonl conversion is used by BatchProcessor."""
+        """model set during json_to_jsonl conversion flows through to BatchProcessor."""
         raw_data = [{"messages": [{"role": "user", "content": "hi"}]}]
         json_path = self.d / "input.json"
         json_path.write_text(json.dumps(raw_data))
         jsonl_path = self.d / "converted.jsonl"
 
-        json_to_jsonl(json_path, jsonl_path, model="special-model")
+        # Use the engine-appropriate model name so validation passes
+        json_to_jsonl(json_path, jsonl_path, model="test/test-model")
 
         entry = json.loads(jsonl_path.read_text().strip())
-        self.assertEqual(entry["body"]["model"], "special-model")
+        self.assertEqual(entry["body"]["model"], "test/test-model")
 
         mock_client = MagicMock()
         mock_client.chat.return_value = "ok"
@@ -502,7 +503,7 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
         processor.run(str(jsonl_path), str(self.d / "out.json"), "vllm")
 
         call_kwargs = mock_client.chat.call_args[1]
-        self.assertEqual(call_kwargs["model"], "special-model")
+        self.assertEqual(call_kwargs["model"], "test/test-model")
 
     @patch("llmflux.processors.batch.LLMClient")
     def test_already_batch_format_passthrough(self, mock_cls):
@@ -513,7 +514,7 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
                 "method": "POST",
                 "url": "/v1/chat/completions",
                 "body": {
-                    "model": "llama3",
+                    "model": "test/test-model",
                     "messages": [{"role": "user", "content": "pre-built"}],
                     "temperature": 0.5,
                     "max_tokens": 100,
@@ -527,7 +528,7 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
         json_to_jsonl(json_path, jsonl_path)
         entry = json.loads(jsonl_path.read_text().strip())
         self.assertEqual(entry["custom_id"], "pre-formatted")
-        self.assertEqual(entry["body"]["model"], "llama3")
+        self.assertEqual(entry["body"]["model"], "test/test-model")
         self.assertEqual(entry["body"]["temperature"], 0.5)
 
         mock_client = MagicMock()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,7 +79,9 @@ class TestBatchProcessorPipeline(unittest.TestCase):
     def _run(self, mock_cls, entries, response="answer", batch_size=4, save_frequency=50, output=None):
         """Wire the mock class so setup() gets a properly configured client."""
         mock_client = MagicMock()
-        mock_client.chat.return_value = response
+        # Tuple form matches the (content, usage) contract client.chat() returns
+        # with return_usage=True, used once benchmarking's batch.py changes land.
+        mock_client.chat.return_value = (response, {})
         mock_cls.return_value = mock_client
         input_path = self.d / "input.jsonl"
         _write_jsonl(input_path, entries)
@@ -470,7 +472,7 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
         self.assertEqual(convert_result["successful_conversions"], 3)
 
         mock_client = MagicMock()
-        mock_client.chat.return_value = "answer"
+        mock_client.chat.return_value = ("answer", {})
         mock_cls.return_value = mock_client
 
         output_path = str(self.d / "results.json")
@@ -496,7 +498,7 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
         self.assertEqual(entry["body"]["model"], "test/test-model")
 
         mock_client = MagicMock()
-        mock_client.chat.return_value = "ok"
+        mock_client.chat.return_value = ("ok", {})
         mock_cls.return_value = mock_client
 
         processor = BatchProcessor(model_config=self.model_config)
@@ -532,7 +534,7 @@ class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
         self.assertEqual(entry["body"]["temperature"], 0.5)
 
         mock_client = MagicMock()
-        mock_client.chat.return_value = "response"
+        mock_client.chat.return_value = ("response", {})
         mock_cls.return_value = mock_client
 
         processor = BatchProcessor(model_config=self.model_config)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,544 @@
+"""Integration tests that exercise multiple components working together."""
+
+import json
+import os
+import tempfile
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from llmflux.converters.json import json_to_jsonl
+from llmflux.converters.utils import merge_jsonl_files, jsonl_to_json, validate_jsonl
+from llmflux.core.config import ModelConfig, ModelParameters
+from llmflux.core.registry import JobRegistry
+from llmflux.processors.batch import BatchProcessor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_model_config():
+    return ModelConfig(
+        name="test:7b",
+        hf_name="test/test-model",
+        parameters=ModelParameters(
+            temperature=0.7, max_tokens=500, top_p=0.9, top_k=40, stop_sequences=None
+        ),
+    )
+
+
+def _write_jsonl(path, entries):
+    with open(path, "w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+CHAT_ENTRY = {
+    "custom_id": "req-1",
+    "method": "POST",
+    "url": "/v1/chat/completions",
+    "body": {
+        "model": "test:7b",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "temperature": 0.7,
+        "max_tokens": 500,
+    },
+}
+
+COMPLETIONS_ENTRY = {
+    "custom_id": "req-comp",
+    "method": "POST",
+    "url": "/v1/completions",
+    "body": {"prompt": "The sky is", "temperature": 0.7, "max_tokens": 50},
+}
+
+UNSUPPORTED_ENTRY = {
+    "custom_id": "req-bad",
+    "method": "POST",
+    "url": "/v1/embeddings",
+    "body": {"input": "text"},
+}
+
+
+# ===========================================================================
+# 1. BatchProcessor end-to-end pipeline
+# ===========================================================================
+
+class TestBatchProcessorPipeline(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmp.name)
+        self.model_config = _make_model_config()
+        self.output = self.d / "output.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, mock_cls, entries, response="answer", batch_size=4, save_frequency=50, output=None):
+        """Wire the mock class so setup() gets a properly configured client."""
+        mock_client = MagicMock()
+        mock_client.chat.return_value = response
+        mock_cls.return_value = mock_client
+        input_path = self.d / "input.jsonl"
+        _write_jsonl(input_path, entries)
+        processor = BatchProcessor(
+            model_config=self.model_config,
+            batch_size=batch_size,
+            save_frequency=save_frequency,
+        )
+        out = str(output or self.output)
+        results = processor.run(str(input_path), out, "vllm")
+        return results, processor, mock_client
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_full_run_writes_output_file(self, mock_cls):
+        """Full pipeline: JSONL in → JSON file out with correct structure."""
+        results, _, _ = self._run(mock_cls, [CHAT_ENTRY], response="Hi there!")
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(self.output.exists())
+        saved = json.loads(self.output.read_text())
+        self.assertEqual(len(saved), 1)
+        self.assertEqual(saved[0]["input"]["custom_id"], "req-1")
+        self.assertIn("Hi there!", str(saved[0]["output"]))
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_batch_chunking_triggers_intermediate_save(self, mock_cls):
+        """With batch_size=1 and save_frequency=1, intermediate file is written each batch."""
+        entries = [dict(CHAT_ENTRY, custom_id=f"req-{i}") for i in range(3)]
+        results, processor, _ = self._run(mock_cls, entries, batch_size=1, save_frequency=1)
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(self.output.exists())
+        self.assertFalse(Path(processor.temp_file).exists())
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_missing_input_raises(self, mock_cls):
+        """FileNotFoundError is raised before any processing if input is missing."""
+        mock_cls.return_value = MagicMock()
+        processor = BatchProcessor(model_config=self.model_config)
+        with self.assertRaises(FileNotFoundError):
+            processor.run(str(self.d / "nonexistent.jsonl"), str(self.output), "vllm")
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_completions_url_routes_correctly(self, mock_cls):
+        """Items with /v1/completions URL are handled and produce text_completion output."""
+        results, _, _ = self._run(mock_cls, [COMPLETIONS_ENTRY], response="blue")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].output["object"], "text_completion")
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_unsupported_url_records_error_and_continues(self, mock_cls):
+        """Unsupported URL produces an error result; processing of other items continues."""
+        results, _, _ = self._run(mock_cls, [UNSUPPORTED_ENTRY, CHAT_ENTRY], response="ok")
+
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(results[0].output)
+        self.assertIsNotNone(results[0].error)
+        self.assertIsNotNone(results[1].output)
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_output_preserves_custom_ids(self, mock_cls):
+        """custom_id flows through unchanged from JSONL to saved output."""
+        entries = [dict(CHAT_ENTRY, custom_id="alpha"), dict(CHAT_ENTRY, custom_id="beta")]
+        self._run(mock_cls, entries, response="response")
+
+        saved = json.loads(self.output.read_text())
+        ids = [r["input"]["custom_id"] for r in saved]
+        self.assertEqual(ids, ["alpha", "beta"])
+
+
+# ===========================================================================
+# 2. CLI jobs + status + cancel commands with real JobRegistry
+# ===========================================================================
+
+class TestJobsCommandIntegration(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.registry_file = Path(self.tmp.name) / "jobs.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _registry_with_jobs(self, jobs: dict):
+        r = JobRegistry(registry_file=str(self.registry_file))
+        for job_id, meta in jobs.items():
+            r.create_job(job_id, meta)
+        return r
+
+    def _args(self, **kwargs):
+        args = MagicMock()
+        args.all = False
+        args.state = []
+        for k, v in kwargs.items():
+            setattr(args, k, v)
+        return args
+
+    @patch("llmflux.cli.JobRegistry")
+    def test_empty_registry_prints_message(self, mock_registry_cls, capsys=None):
+        from llmflux.cli import _jobs_command
+        mock_registry_cls.return_value.get_all_jobs.return_value = {}
+        args = self._args()
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _jobs_command(args)
+        self.assertEqual(result, 0)
+
+    @patch("llmflux.cli.get_list_of_jobs_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_all_flag_renders_table(self, mock_registry_cls, mock_get_list):
+        from llmflux.cli import _jobs_command
+        mock_registry_cls.return_value.get_all_jobs.return_value = {
+            "111": {"job_name": "flux_job", "model": "llama3", "engine": "vllm", "submitted_at": None}
+        }
+        mock_get_list.return_value = {
+            "111": {"job_id": 111, "job_state": "COMPLETED"}
+        }
+        args = self._args(all=True)
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _jobs_command(args)
+            output = out.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("111", output)
+        self.assertIn("COMPLETED", output)
+
+    @patch("llmflux.cli.get_active_job_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_default_shows_only_active_jobs(self, mock_registry_cls, mock_get_active):
+        from llmflux.cli import _jobs_command
+        mock_registry_cls.return_value.get_all_jobs.return_value = {
+            "222": {"job_name": "active_job", "model": "llama3", "engine": "vllm", "submitted_at": None}
+        }
+        mock_get_active.return_value = {
+            "222": {"job_id": 222, "job_state": "RUNNING"}
+        }
+        args = self._args(all=False)
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _jobs_command(args)
+            output = out.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("222", output)
+        self.assertIn("RUNNING", output)
+
+    @patch("llmflux.cli.get_list_of_jobs_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_state_filter_excludes_non_matching(self, mock_registry_cls, mock_get_list):
+        from llmflux.cli import _jobs_command
+        mock_registry_cls.return_value.get_all_jobs.return_value = {
+            "333": {"job_name": "done", "model": "m", "engine": "e", "submitted_at": None},
+            "444": {"job_name": "running", "model": "m", "engine": "e", "submitted_at": None},
+        }
+        mock_get_list.return_value = {
+            "333": {"job_id": 333, "job_state": "COMPLETED"},
+            "444": {"job_id": 444, "job_state": "RUNNING"},
+        }
+        args = self._args(all=True, state=["COMPLETED"])
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _jobs_command(args)
+            output = out.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("333", output)
+        self.assertNotIn("444", output)
+
+    @patch("llmflux.cli.get_active_job_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_active_job_not_in_registry_excluded(self, mock_registry_cls, mock_get_active):
+        """Slurm reports a job as active but it's not in LLMFlux registry — excluded."""
+        from llmflux.cli import _jobs_command
+        mock_registry_cls.return_value.get_all_jobs.return_value = {}
+        mock_get_active.return_value = {
+            "999": {"job_id": 999, "job_state": "RUNNING"}
+        }
+        args = self._args(all=False)
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _jobs_command(args)
+        self.assertEqual(result, 0)
+
+
+class TestStatusCommandIntegration(unittest.TestCase):
+    def _args(self, job_id="123"):
+        args = MagicMock()
+        args.job_id = job_id
+        return args
+
+    @patch("llmflux.cli.get_job_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_job_not_found_anywhere_returns_error(self, mock_registry_cls, mock_get_details):
+        from llmflux.cli import _status_command
+        mock_registry_cls.return_value.get_job.return_value = None
+        mock_get_details.return_value = {}
+        with patch("sys.stderr", new=StringIO()):
+            result = _status_command(self._args())
+        self.assertEqual(result, 1)
+
+    @patch("llmflux.cli.get_job_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_slurm_error_returns_error(self, mock_registry_cls, mock_get_details):
+        from llmflux.cli import _status_command
+        from llmflux.slurm.commands import SlurmCommandError
+        mock_registry_cls.return_value.get_job.return_value = None
+        mock_get_details.side_effect = SlurmCommandError("sacct failed")
+        with patch("sys.stderr", new=StringIO()):
+            result = _status_command(self._args())
+        self.assertEqual(result, 1)
+
+    @patch("llmflux.cli.get_job_log_paths")
+    @patch("llmflux.cli.get_job_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_job_in_slurm_only_shows_details(self, mock_registry_cls, mock_get_details, mock_log_paths):
+        from llmflux.cli import _status_command
+        mock_registry_cls.return_value.get_job.return_value = None
+        mock_get_details.return_value = {
+            "job_id": 123,
+            "job_state": "COMPLETED",
+            "partition": "gpuA100",
+        }
+        mock_log_paths.return_value = ("/tmp/123.out", "/tmp/123.err")
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _status_command(self._args())
+            output = out.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("123", output)
+        self.assertIn("COMPLETED", output)
+
+    @patch("llmflux.cli.get_job_log_paths")
+    @patch("llmflux.cli.get_job_details")
+    @patch("llmflux.cli.JobRegistry")
+    def test_job_in_both_merges_registry_and_slurm(self, mock_registry_cls, mock_get_details, mock_log_paths):
+        from llmflux.cli import _status_command
+        mock_registry_cls.return_value.get_job.return_value = {
+            "job_name": "my_job",
+            "model": "llama3",
+            "engine": "vllm",
+            "submitted_at": None,
+            "workspace": "/work",
+            "input": "data.jsonl",
+            "output": "out.json",
+            "logs_dir": "/logs",
+        }
+        mock_get_details.return_value = {
+            "job_id": 123,
+            "job_state": "RUNNING",
+            "partition": "gpuA100",
+        }
+        mock_log_paths.return_value = ("/logs/123.out", "/logs/123.err")
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _status_command(self._args())
+            output = out.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("llama3", output)
+        self.assertIn("vllm", output)
+        self.assertIn("RUNNING", output)
+
+
+class TestCancelCommandIntegration(unittest.TestCase):
+    def _args(self, job_id="123", force=False):
+        args = MagicMock()
+        args.job_id = job_id
+        args.force = force
+        return args
+
+    @patch("llmflux.cli.JobRegistry")
+    def test_job_not_in_registry_returns_error(self, mock_registry_cls):
+        from llmflux.cli import _cancel_command
+        mock_registry_cls.return_value.get_job.return_value = None
+        with patch("sys.stderr", new=StringIO()):
+            result = _cancel_command(self._args())
+        self.assertEqual(result, 1)
+
+    @patch("llmflux.cli.cancel_job")
+    @patch("llmflux.cli.JobRegistry")
+    def test_cancel_success(self, mock_registry_cls, mock_cancel):
+        from llmflux.cli import _cancel_command
+        mock_registry_cls.return_value.get_job.return_value = {"job_name": "job"}
+        mock_cancel.return_value = None
+        with patch("sys.stdout", new=StringIO()) as out:
+            result = _cancel_command(self._args())
+            output = out.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("cancelled", output)
+        mock_cancel.assert_called_once_with("123", force=False)
+
+    @patch("llmflux.cli.cancel_job")
+    @patch("llmflux.cli.JobRegistry")
+    def test_cancel_slurm_error_returns_error(self, mock_registry_cls, mock_cancel):
+        from llmflux.cli import _cancel_command
+        from llmflux.slurm.commands import SlurmCommandError
+        mock_registry_cls.return_value.get_job.return_value = {"job_name": "job"}
+        mock_cancel.side_effect = SlurmCommandError("permission denied")
+        with patch("sys.stderr", new=StringIO()):
+            result = _cancel_command(self._args())
+        self.assertEqual(result, 1)
+
+    @patch("llmflux.cli.cancel_job")
+    @patch("llmflux.cli.JobRegistry")
+    def test_force_flag_forwarded(self, mock_registry_cls, mock_cancel):
+        from llmflux.cli import _cancel_command
+        mock_registry_cls.return_value.get_job.return_value = {"job_name": "job"}
+        mock_cancel.return_value = None
+        with patch("sys.stdout", new=StringIO()):
+            _cancel_command(self._args(force=True))
+        mock_cancel.assert_called_once_with("123", force=True)
+
+
+# ===========================================================================
+# 3. Converter utilities — cross-file operations
+# ===========================================================================
+
+class TestConverterUtilitiesIntegration(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, filename, lines):
+        p = self.d / filename
+        p.write_text("\n".join(lines) + "\n")
+        return str(p)
+
+    def test_merge_skips_missing_file(self):
+        """merge_jsonl_files silently skips a file that does not exist."""
+        real = self._write("real.jsonl", ['{"a": 1}', '{"a": 2}'])
+        missing = str(self.d / "ghost.jsonl")
+        out = str(self.d / "merged.jsonl")
+        merge_jsonl_files([real, missing], out)
+        lines = [l for l in Path(out).read_text().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2)
+
+    def test_merge_skips_invalid_json_lines(self):
+        """merge_jsonl_files skips malformed lines, keeps valid ones."""
+        f1 = self._write("f1.jsonl", ['{"ok": 1}', "{bad json}", '{"ok": 2}'])
+        out = str(self.d / "merged.jsonl")
+        merge_jsonl_files([f1], out)
+        lines = [l for l in Path(out).read_text().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(json.loads(lines[0]), {"ok": 1})
+        self.assertEqual(json.loads(lines[1]), {"ok": 2})
+
+    def test_jsonl_to_json_round_trip(self):
+        """JSONL written then converted to JSON preserves all entries."""
+        entries = [{"id": i, "v": f"val{i}"} for i in range(5)]
+        jsonl_path = self.d / "data.jsonl"
+        _write_jsonl(str(jsonl_path), entries)
+        json_path = str(self.d / "data.json")
+        jsonl_to_json(str(jsonl_path), json_path)
+        loaded = json.loads(Path(json_path).read_text())
+        self.assertEqual(loaded, entries)
+
+    def test_validate_jsonl_with_one_bad_line(self):
+        """validate_jsonl returns False when any line is malformed."""
+        path = self._write("mixed.jsonl", ['{"good": true}', "not-json", '{"also": "good"}'])
+        self.assertFalse(validate_jsonl(path))
+
+    def test_validate_jsonl_all_valid(self):
+        entries = [{"id": i} for i in range(4)]
+        path = self.d / "valid.jsonl"
+        _write_jsonl(str(path), entries)
+        self.assertTrue(validate_jsonl(str(path)))
+
+
+# ===========================================================================
+# 4. JSON → JSONL → BatchProcessor full pipeline
+# ===========================================================================
+
+class TestJsonToJsonlToBatchProcessorPipeline(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmp.name)
+        self.model_config = _make_model_config()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_json_array_converted_and_processed(self, mock_cls):
+        """Raw JSON → json_to_jsonl → BatchProcessor produces one result per entry."""
+        raw_data = [
+            {"messages": [{"role": "user", "content": f"Question {i}"}]}
+            for i in range(3)
+        ]
+        json_path = self.d / "input.json"
+        json_path.write_text(json.dumps(raw_data))
+        jsonl_path = self.d / "converted.jsonl"
+
+        convert_result = json_to_jsonl(json_path, jsonl_path, model="test:7b")
+        self.assertTrue(convert_result["success"])
+        self.assertEqual(convert_result["successful_conversions"], 3)
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "answer"
+        mock_cls.return_value = mock_client
+
+        output_path = str(self.d / "results.json")
+        processor = BatchProcessor(model_config=self.model_config)
+        results = processor.run(str(jsonl_path), output_path, "vllm")
+
+        self.assertEqual(len(results), 3)
+        saved = json.loads(Path(output_path).read_text())
+        self.assertEqual(len(saved), 3)
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_model_field_survives_pipeline(self, mock_cls):
+        """model set during json_to_jsonl conversion is used by BatchProcessor."""
+        raw_data = [{"messages": [{"role": "user", "content": "hi"}]}]
+        json_path = self.d / "input.json"
+        json_path.write_text(json.dumps(raw_data))
+        jsonl_path = self.d / "converted.jsonl"
+
+        json_to_jsonl(json_path, jsonl_path, model="special-model")
+
+        entry = json.loads(jsonl_path.read_text().strip())
+        self.assertEqual(entry["body"]["model"], "special-model")
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "ok"
+        mock_cls.return_value = mock_client
+
+        processor = BatchProcessor(model_config=self.model_config)
+        processor.run(str(jsonl_path), str(self.d / "out.json"), "vllm")
+
+        call_kwargs = mock_client.chat.call_args[1]
+        self.assertEqual(call_kwargs["model"], "special-model")
+
+    @patch("llmflux.processors.batch.LLMClient")
+    def test_already_batch_format_passthrough(self, mock_cls):
+        """Items already in batch format pass through json_to_jsonl unchanged."""
+        raw_data = [
+            {
+                "custom_id": "pre-formatted",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model": "llama3",
+                    "messages": [{"role": "user", "content": "pre-built"}],
+                    "temperature": 0.5,
+                    "max_tokens": 100,
+                },
+            }
+        ]
+        json_path = self.d / "batch_input.json"
+        json_path.write_text(json.dumps(raw_data))
+        jsonl_path = self.d / "converted.jsonl"
+
+        json_to_jsonl(json_path, jsonl_path)
+        entry = json.loads(jsonl_path.read_text().strip())
+        self.assertEqual(entry["custom_id"], "pre-formatted")
+        self.assertEqual(entry["body"]["model"], "llama3")
+        self.assertEqual(entry["body"]["temperature"], 0.5)
+
+        mock_client = MagicMock()
+        mock_client.chat.return_value = "response"
+        mock_cls.return_value = mock_client
+
+        processor = BatchProcessor(model_config=self.model_config)
+        results = processor.run(str(jsonl_path), str(self.d / "out.json"), "vllm")
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Bug fix**: `serve()` was missing the tensor-parallel auto-set added to `run()` in the `fixing_oom_issue` PR — multi-GPU `serve` jobs defaulted to 1 GPU and caused OOM. Ported the same logic to `serve()` so both paths behave consistently.
- **New tests (runner)**: 7 tests covering `run()` and `serve()` multi-GPU paths — auto-set when `gpus_per_node > 1`, user-supplied `tensor-parallel-size` is not overridden, single-GPU leaves `VLLM_ENGINE_ARGS` clean; also verifies that `serve()` sets `VLLM_MODEL_NAME`, `VLLM_HOST`, and `VLLM_ENGINE_ARGS`.
- **New tests (batch)**: 4 tests for `_get_validated_model` — `/v1/completions` rejects mismatched model, accepts matching model, no `model` key falls back to config, direct `ValueError` on mismatch.
- **Integration test fix**: `CHAT_ENTRY` and related fixtures used `"test:7b"` (Ollama name) but tests run with the vllm engine, whose engine model name is `"test/test-model"`. Updated all fixtures to use the HuggingFace model name so the `_get_validated_model` check passes correctly.
- **Merge**: Branch updated from `main` (includes `fixing_oom_issue` — vLLM GPU count fix and Mixtral YAML update).

## Test plan

- [ ] `pytest tests/slurm/test_runner.py` — all runner tests including 7 new multi-GPU cases
- [ ] `pytest tests/processors/test_batch.py` — all batch tests including 4 new `_get_validated_model` cases
- [ ] `pytest tests/test_integration.py` — integration pipeline tests pass with corrected model names
- [ ] Full suite: `pytest -q` — 76 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)