### PR TITLE
fix(ollama): don't `module purge` in the generated SLURM script (breaks host-side batch processor)

### DIFF
--- a/src/llmflux/slurm/engine/ollama.py
+++ b/src/llmflux/slurm/engine/ollama.py
@@ -45,26 +45,16 @@ def create_ollama_batch_script(
             f"#SBATCH --mail-user={email}",
         ])
 
+    # NOTE: Do NOT `module purge` (or load host gcc/cuda) here. The batch
+    # processor further down runs on the *host* and does `import llmflux`, which
+    # resolves via the environment that `module load llmflux` put on PATH.
+    # Purging it left `python3` as a base interpreter without llmflux, so the
+    # processor died with `ModuleNotFoundError: No module named 'llmflux'` while
+    # the ollama server (in the container) was otherwise healthy. The container
+    # ships its own CUDA, so no host toolchain modules are needed here, and the
+    # hardcoded gcc/cuda module names matched nothing on our clusters anyway.
+    # vllm.py never purged, which is why the vLLM engine was unaffected.
     job_script.extend([
-        "",
-        "# Load required modules",
-        "module purge",
-        "",
-        "# Try loading GCC",
-        "for gcc_version in '11.4.0' '11.3.0'; do",
-        "    if module load gcc/$gcc_version &>/dev/null; then",
-        "        echo \"Loaded gcc/$gcc_version\"",
-        "        break",
-        "    fi",
-        "done",
-        "",
-        "# Try loading CUDA",
-        "for cuda_version in '12.2.1' '11.7.0'; do",
-        "    if module load cuda/$cuda_version &>/dev/null; then",
-        "        echo \"Loaded cuda/$cuda_version\"",
-        "        break",
-        "    fi",
-        "done",
         "",
         "# Create all necessary directories",
         "mkdir -p $DATA_INPUT_DIR $DATA_OUTPUT_DIR $MODELS_DIR $LOGS_DIR $CONTAINERS_DIR $APPTAINER_TMPDIR $APPTAINER_CACHEDIR",


### PR DESCRIPTION
Fixes #114

## Summary

`llmflux run --engine ollama` fails with `ModuleNotFoundError: No module named 'llmflux'`, while `--engine vllm` succeeds on the same node with the same environment. The only relevant difference is a single `module purge` that `slurm/engine/ollama.py` emits and `slurm/engine/vllm.py` does not.

## Root cause

Both engines run the batch client on the **host** as a bare `python3 -c "import llmflux ..."`. `llmflux run` submits with the inherited environment (`sbatch --export=ALL`), where `module load llmflux/<v>` has put the env's `bin/` on `PATH`. `create_ollama_batch_script()` runs `module purge` near the top of the generated script, stripping the llmflux module from `PATH`; the host `python3` then falls back to a base interpreter without llmflux -> `ModuleNotFoundError`. `vllm.py` has no purge, so it works.

The `gcc/*` + `cuda/*` load loop after the purge matched no module on our clusters (silent no-op), and the container ships its own CUDA — so the whole preamble was dead code plus one harmful line. The ollama **backend itself is healthy**: in the failing runs the server started and the model pulled; only the host processor step crashed.

## Fix

Remove `module purge` and the dead toolchain-load loop from `create_ollama_batch_script()`, matching `vllm.py`. One-line behavioral change; the rest is deleting dead code + a rationale comment.

_Optional follow-up (not in this PR):_ both engines invoke the host processor as bare `python3`; templating the interpreter from `sys.executable` captured at submit time would make it robust to any future `PATH`/module changes.

## Verification

llmflux 0.1.5, on both **DeltaAI** (GH200 / aarch64) and **Delta** (A100 + H200 / x86_64):

- as-shipped ollama fails identically (`ModuleNotFoundError: No module named 'llmflux'`);
- with this exact change (verified via a job-script shim that strips only this line), the batch completes **3/3** correct;
- vLLM passes as shipped on both.

## Test plan

On a clean-module HPC system: `module load llmflux`, then

```
llmflux run --model Qwen2.5-1.5B-Instruct --engine ollama \
  --input prompts.jsonl --output out.json \
  --account <A> --partition <P> --gpus-per-node 1
```

- **Before:** job runs, ollama server starts, model pulls, host processor exits with `ModuleNotFoundError`.
- **After:** the batch completes and writes `out.json`.
