### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmflux"
-version = "0.1.5"
+version = "1.0.0"
 description = "CLI tool for running LLM batch processing jobs on HPC systems"
 readme = "docs/README.md"
 license = {text = "MIT"}
@@ -14,7 +14,7 @@ authors = [
 requires-python = ">=3.11"
 keywords = ["llm", "batch-processing", "slurm", "hpc", "ai", "machine-learning", "ollama", "vllm"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.5 to 1.0.0 for the first stable release
- Update PyPI classifier from `Development Status :: 4 - Beta` to `5 - Production/Stable`

## Verification
- Full test suite (417 tests) passes on main at 667dab1
- Wheel builds cleanly; `llmflux --version` reports 1.0.0 from an editable install
- Version is sourced solely from `pyproject.toml` (CLI reads package metadata), so no other files need updating

## Release steps after merge
1. Publish a GitHub release with tag `v1.0.0` targeting main
2. The `publish.yml` workflow will build and push to PyPI via trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)