### PR TITLE
security: validate node/port from connection.json to prevent SSRF (#109)

### DIFF
--- a/.claude/hooks/check-tests.sh
+++ b/.claude/hooks/check-tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Stop hook (warn-only): when a turn leaves uncommitted changes under src/ or
+# tests/, run the test suite and surface the result to the user, plus a nudge
+# if source changed without any accompanying test change.
+#
+# This NEVER blocks — it only prints a systemMessage. It exists to reinforce
+# the rule in AGENTS.md: every code change ships with tests, and the suite must
+# pass before the work is done. See `/hooks` to review or disable it.
+set -uo pipefail
+
+emit() {  # print a non-blocking systemMessage as JSON on stdout
+  MSG="$1" python3 -c 'import json, os; print(json.dumps({"systemMessage": os.environ["MSG"]}))'
+}
+
+# No-op outside a git work tree.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Only act when this turn left uncommitted changes under src/ or tests/.
+[ -n "$(git status --porcelain -- src tests 2>/dev/null)" ] || exit 0
+
+src_changed="$(git status --porcelain -- src 2>/dev/null)"
+tests_changed="$(git status --porcelain -- tests 2>/dev/null)"
+
+note=""
+if [ -n "$src_changed" ] && [ -z "$tests_changed" ]; then
+  note="⚠ src/ changed but no tests/ files were touched — add or update tests for this change (see AGENTS.md)."$'\n\n'
+fi
+
+if out="$(python3 -m pytest -q 2>&1)"; then
+  emit "${note}✓ Tests: $(printf '%s\n' "$out" | tail -n 1)"
+else
+  emit "${note}✗ Tests FAILED — fix before finishing (see AGENTS.md):"$'\n'"$(printf '%s\n' "$out" | tail -n 12)"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/check-tests.sh\"",
+            "timeout": 120,
+            "statusMessage": "Checking tests..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ data/*
 
 # Benchmark data
 src/llmflux/benchmark_data/*
+
+# Claude Code personal overrides (keep settings.json and hooks tracked)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Working on LLMFlux with an AI assistant
+
+Guidance for anyone using Claude Code (or another AI coding assistant) on this
+repo, and for the assistants themselves. Keep it in context when making changes.
+
+## Tests are not optional
+
+**Every code change must come with tests.** This is the single most important
+rule in this file. When you add or modify behavior, add or update the tests that
+cover it in the same change — do not defer it, and do not treat "the existing
+tests still pass" as sufficient.
+
+Concretely:
+
+- **New function or branch** → add tests for the happy path *and* the failure /
+  edge cases (empty input, malformed input, boundary values).
+- **Bug fix** → add a regression test that fails before your fix and passes
+  after. State that expectation in the PR/commit so a reviewer can verify it.
+- **Security fix** → add tests for the specific bypass or exploit you closed,
+  using the concrete malicious inputs, not just a generic "invalid" case. See
+  `tests/slurm/test_connection.py` for the pattern (encoded-IP SSRF bypasses are
+  each pinned by a test).
+- **Changed public behavior** → update the affected tests and the docs under
+  `docs/` in the same change.
+
+If a change genuinely has no observable behavior to test (pure docs, comments,
+formatting), say so explicitly in the PR description rather than silently
+shipping without tests.
+
+## For AI assistants specifically
+
+- **Add tests by default.** Treat "write the code" as "write the code and its
+  tests." Do not ask whether tests are wanted — assume yes and include them.
+- **Run the suite before reporting done.** A change is not finished until
+  `python -m pytest` passes locally. Report the actual result (pass count /
+  failures), never assume.
+- **Match the existing test style.** Tests use `unittest.TestCase` classes with
+  `unittest.mock` (`patch`, `MagicMock`); mirror the conventions in the
+  neighboring test file rather than introducing a new framework or style.
+- **Verify the fix actually exercises the change** — drive the real code path
+  (e.g. call `connect()` end-to-end), not just the helper in isolation.
+- **Keep changes scoped.** Don't stage or commit unrelated working-tree files;
+  commit only what the task touched.
+
+## Running tests
+
+```bash
+# Install test dependencies (once)
+pip install -e ".[test]"
+
+# Run the full suite
+python -m pytest
+
+# Run one file / one test
+python -m pytest tests/slurm/test_connection.py
+python -m pytest tests/slurm/test_connection.py::TestValidateNode
+```
+
+Test layout mirrors the package: tests live under `tests/`, named `test_*.py`.
+See `docs/TESTING.md` for coverage reports, parallel runs, and more detail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,16 @@ python -m pytest tests/slurm/test_connection.py::TestValidateNode
 
 Test layout mirrors the package: tests live under `tests/`, named `test_*.py`.
 See `docs/TESTING.md` for coverage reports, parallel runs, and more detail.
+
+## Automated reminder (Claude Code hook)
+
+This repo ships a committed Claude Code `Stop` hook
+(`.claude/settings.json` → `.claude/hooks/check-tests.sh`). When a turn leaves
+uncommitted changes under `src/` or `tests/`, it runs the suite and surfaces the
+result, and nudges you if `src/` changed without any accompanying test change.
+
+It is **warn-only** — it never blocks — and is a backstop for the rule above,
+not a substitute for it. Review or disable it via `/hooks`. Contributors using a
+different assistant won't get the reminder, so the "tests with every change"
+rule stands on its own regardless of tooling.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+See [AGENTS.md](AGENTS.md) for guidance on working in this repo with an AI assistant.
+
+The most important rule: **every code change ships with tests in the same change,
+and `python -m pytest` must pass before the work is considered done.** Add tests
+by default — don't ask whether they're wanted.

--- a/src/llmflux/slurm/connection.py
+++ b/src/llmflux/slurm/connection.py
@@ -1,7 +1,9 @@
 """Connection helpers for llmflux serve jobs."""
 
+import ipaddress
 import json
 import os
+import re
 import sys
 import time
 import urllib.request
@@ -9,10 +11,82 @@ import urllib.error
 from pathlib import Path
 from typing import Optional
 
+# RFC 1123 hostname: dot-separated labels of alphanumerics and hyphens,
+# no leading/trailing hyphen. Also matches IPv4 literals, which are
+# checked separately against reserved ranges below.
+_HOSTNAME_RE = re.compile(
+    r"^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$"
+)
+
+# Engine servers always bind unprivileged ports; anything below 1024
+# (ssh, smtp, ...) is an SSRF probe target, not a legitimate endpoint.
+_MIN_PORT = 1024
+_MAX_PORT = 65535
+
 
 def _sanitize(value: str) -> str:
     """Strip non-ASCII bytes to prevent terminal control-character injection."""
     return value.encode("ascii", errors="replace").decode("ascii")
+
+
+def _validate_node(node: str) -> None:
+    """Reject node values that could redirect the request to an unintended target.
+
+    The connection file lives on a shared filesystem; if another user managed
+    to plant one, an unvalidated node/port would let them steer our HTTP
+    request (SSRF) or inject options into the suggested ssh tunnel command.
+
+    Raises:
+        ValueError: if node is not a plausible cluster-node hostname.
+    """
+    if not node or not _HOSTNAME_RE.match(node):
+        raise ValueError(
+            f"node {node!r} is not a valid hostname "
+            f"(letters, digits, hyphens, and dots only)"
+        )
+    labels = node.lower().split(".")
+    if "localhost" in (labels[0], labels[-1]):
+        raise ValueError(f"node {node!r} is a loopback address")
+    try:
+        addr = ipaddress.ip_address(node)
+    except ValueError:
+        pass  # a hostname, not an IP literal
+    else:
+        if (
+            addr.is_loopback
+            or addr.is_link_local
+            or addr.is_multicast
+            or addr.is_unspecified
+            or addr.is_reserved
+        ):
+            raise ValueError(
+                f"node {node!r} is a loopback, link-local, or reserved address"
+            )
+    pattern = os.environ.get("LLMFLUX_NODE_PATTERN")
+    if pattern:
+        try:
+            matched = re.fullmatch(pattern, node)
+        except re.error as exc:
+            raise ValueError(
+                f"LLMFLUX_NODE_PATTERN is not a valid regular expression: {exc}"
+            )
+        if not matched:
+            raise ValueError(
+                f"node {node!r} does not match LLMFLUX_NODE_PATTERN ({pattern!r})"
+            )
+
+
+def _validate_port(port: int) -> None:
+    """Reject ports outside the unprivileged range.
+
+    Raises:
+        ValueError: if port is not in [1024, 65535].
+    """
+    if not _MIN_PORT <= port <= _MAX_PORT:
+        raise ValueError(
+            f"port {port} is outside the allowed range "
+            f"{_MIN_PORT}-{_MAX_PORT} for serve endpoints"
+        )
 
 
 def _connection_file_path(job_id: str) -> Path:
@@ -135,6 +209,17 @@ def connect(job_id: str, local_port: int = 8000, wait_timeout: int = 600) -> int
     except (ValueError, TypeError):
         print(
             f"Error: connection file has an invalid port value: {info['port']!r}. "
+            f"Check logs with: llmflux logs {job_id}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        _validate_node(node)
+        _validate_port(port)
+    except ValueError as exc:
+        print(
+            f"Error: refusing to connect — {exc}. "
+            f"The connection file may have been tampered with. "
             f"Check logs with: llmflux logs {job_id}",
             file=sys.stderr,
         )

--- a/src/llmflux/slurm/connection.py
+++ b/src/llmflux/slurm/connection.py
@@ -4,6 +4,7 @@ import ipaddress
 import json
 import os
 import re
+import socket
 import sys
 import time
 import urllib.request
@@ -29,6 +30,17 @@ def _sanitize(value: str) -> str:
     return value.encode("ascii", errors="replace").decode("ascii")
 
 
+def _is_forbidden_address(addr: "ipaddress._BaseAddress") -> bool:
+    """True if addr is a loopback, link-local, multicast, unspecified, or reserved IP."""
+    return (
+        addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_unspecified
+        or addr.is_reserved
+    )
+
+
 def _validate_node(node: str) -> None:
     """Reject node values that could redirect the request to an unintended target.
 
@@ -52,13 +64,7 @@ def _validate_node(node: str) -> None:
     except ValueError:
         pass  # a hostname, not an IP literal
     else:
-        if (
-            addr.is_loopback
-            or addr.is_link_local
-            or addr.is_multicast
-            or addr.is_unspecified
-            or addr.is_reserved
-        ):
+        if _is_forbidden_address(addr):
             raise ValueError(
                 f"node {node!r} is a loopback, link-local, or reserved address"
             )
@@ -73,6 +79,29 @@ def _validate_node(node: str) -> None:
         if not matched:
             raise ValueError(
                 f"node {node!r} does not match LLMFLUX_NODE_PATTERN ({pattern!r})"
+            )
+    # ipaddress.ip_address() only accepts canonical dotted-quad IPv4, but the
+    # OS resolver urllib uses also honors legacy encodings — decimal
+    # (2852039166), hex (0xA9FEA9FE), octal, and short (127.1) forms — which
+    # slip past the literal check above as "hostnames" yet still resolve to
+    # loopback/metadata targets. Resolve the node the same way urllib will and
+    # re-check every address it maps to (also catches a hostname pointed at an
+    # internal IP). Unresolvable names are left alone: _ping_endpoint simply
+    # fails on them, so there is no SSRF reach to guard against.
+    try:
+        resolved = socket.getaddrinfo(node, None)
+    except socket.gaierror:
+        return
+    for *_, sockaddr in resolved:
+        ip = sockaddr[0]
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if _is_forbidden_address(addr):
+            raise ValueError(
+                f"node {node!r} resolves to a loopback, link-local, or "
+                f"reserved address ({ip})"
             )
 
 

--- a/src/llmflux/slurm/engine/ollama.py
+++ b/src/llmflux/slurm/engine/ollama.py
@@ -145,8 +145,8 @@ def create_ollama_batch_script(
         *([
             "# Write connection file for llmflux connect (restrict permissions — contains API key)",
             "# CONNECTION_FILE was defined earlier alongside the cleanup trap.",
-            "mkdir -p \"$(dirname $CONNECTION_FILE)\"",
-            "chmod 700 \"$(dirname $CONNECTION_FILE)\"",
+            "(umask 077 && mkdir -p \"$(dirname $CONNECTION_FILE)\")",
+            "chmod 700 \"$HOME/.llmflux\" \"$HOME/.llmflux/serve\" \"$(dirname $CONNECTION_FILE)\"",
             "(umask 077 && cat > \"$CONNECTION_FILE\" <<EOF",
             "{",
             "  \"job_id\": \"$SLURM_JOB_ID\",",

--- a/src/llmflux/slurm/engine/vllm.py
+++ b/src/llmflux/slurm/engine/vllm.py
@@ -144,8 +144,8 @@ def create_vllm_batch_script(
         *([
             "# Write connection file for llmflux connect (restrict permissions — contains API key)",
             "# CONNECTION_FILE was defined earlier alongside the cleanup trap.",
-            "mkdir -p \"$(dirname $CONNECTION_FILE)\"",
-            "chmod 700 \"$(dirname $CONNECTION_FILE)\"",
+            "(umask 077 && mkdir -p \"$(dirname $CONNECTION_FILE)\")",
+            "chmod 700 \"$HOME/.llmflux\" \"$HOME/.llmflux/serve\" \"$(dirname $CONNECTION_FILE)\"",
             "(umask 077 && cat > \"$CONNECTION_FILE\" <<EOF",
             "{",
             "  \"job_id\": \"$SLURM_JOB_ID\",",

--- a/tests/slurm/test_connection.py
+++ b/tests/slurm/test_connection.py
@@ -1,6 +1,7 @@
 """Tests for llmflux.slurm.connection helpers."""
 
 import json
+import socket
 import tempfile
 import unittest
 import urllib.error
@@ -208,6 +209,33 @@ class TestValidateNode(unittest.TestCase):
         # Colons fail the hostname pattern, which also covers ::1
         with self.assertRaises(ValueError):
             _validate_node("::1")
+
+    def test_rejects_encoded_loopback_ip(self):
+        # Legacy IPv4 encodings that ipaddress.ip_address() rejects but the
+        # OS resolver maps to 127.0.0.1 (getaddrinfo parses these locally).
+        for node in ("2130706433", "0x7f000001", "0177.0.0.1", "127.1"):
+            with self.assertRaises(ValueError):
+                _validate_node(node)
+
+    def test_rejects_encoded_metadata_ip(self):
+        # Decimal/hex/short forms of the 169.254.169.254 cloud metadata IP.
+        for node in ("2852039166", "0xA9FEA9FE", "169.254.43518"):
+            with self.assertRaises(ValueError):
+                _validate_node(node)
+
+    @patch("llmflux.slurm.connection.socket.getaddrinfo")
+    def test_rejects_hostname_resolving_to_internal_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0))
+        ]
+        with self.assertRaises(ValueError):
+            _validate_node("innocent-looking-host")
+
+    @patch("llmflux.slurm.connection.socket.getaddrinfo", side_effect=socket.gaierror)
+    def test_allows_unresolvable_hostname(self, mock_getaddrinfo):
+        # An unresolvable name can't be pinged, so there is no SSRF reach to
+        # guard against; validation must not reject it.
+        _validate_node("gpub073")  # must not raise
 
     def test_rejects_empty_and_malformed(self):
         for node in ("", "-leading-hyphen", "trailing-hyphen-.x", "has space", "a/b", "node:8000"):

--- a/tests/slurm/test_connection.py
+++ b/tests/slurm/test_connection.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, call, patch
 
 from llmflux.slurm.connection import (
     _ping_endpoint,
+    _validate_node,
+    _validate_port,
     connect,
     read_connection_info,
     wait_for_connection_file,
@@ -178,6 +180,109 @@ class TestPingEndpoint(unittest.TestCase):
         url_used = mock_urlopen.call_args[0][0]
         self.assertIn("gpu-node-07", url_used)
         self.assertIn("9999", url_used)
+
+
+class TestValidateNode(unittest.TestCase):
+    def test_accepts_cluster_hostnames(self):
+        for node in ("gpu-node-01", "gpub073", "gpub073.delta.ncsa.illinois.edu"):
+            _validate_node(node)  # must not raise
+
+    def test_accepts_private_ipv4(self):
+        _validate_node("10.1.2.3")
+
+    def test_rejects_localhost(self):
+        for node in ("localhost", "LOCALHOST", "localhost.localdomain", "evil.localhost"):
+            with self.assertRaises(ValueError):
+                _validate_node(node)
+
+    def test_rejects_loopback_ip(self):
+        for node in ("127.0.0.1", "127.1.2.3"):
+            with self.assertRaises(ValueError):
+                _validate_node(node)
+
+    def test_rejects_link_local_metadata_ip(self):
+        with self.assertRaises(ValueError):
+            _validate_node("169.254.169.254")
+
+    def test_rejects_ipv6_loopback(self):
+        # Colons fail the hostname pattern, which also covers ::1
+        with self.assertRaises(ValueError):
+            _validate_node("::1")
+
+    def test_rejects_empty_and_malformed(self):
+        for node in ("", "-leading-hyphen", "trailing-hyphen-.x", "has space", "a/b", "node:8000"):
+            with self.assertRaises(ValueError):
+                _validate_node(node)
+
+    def test_rejects_ssh_option_injection(self):
+        with self.assertRaises(ValueError):
+            _validate_node("-oProxyCommand=evil")
+
+    @patch.dict("os.environ", {"LLMFLUX_NODE_PATTERN": r"gpu-node-\d+"})
+    def test_node_pattern_env_var_enforced(self):
+        _validate_node("gpu-node-07")
+        with self.assertRaises(ValueError):
+            _validate_node("other-host")
+
+    @patch.dict("os.environ", {"LLMFLUX_NODE_PATTERN": r"gpu-node-\d+"})
+    def test_node_pattern_must_match_full_hostname(self):
+        with self.assertRaises(ValueError):
+            _validate_node("gpu-node-07.evil.example.com")
+
+    @patch.dict("os.environ", {"LLMFLUX_NODE_PATTERN": "[invalid"})
+    def test_invalid_node_pattern_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _validate_node("gpu-node-07")
+
+
+class TestValidatePort(unittest.TestCase):
+    def test_accepts_unprivileged_ports(self):
+        for port in (1024, 8000, 11434, 65535):
+            _validate_port(port)  # must not raise
+
+    def test_rejects_privileged_and_out_of_range_ports(self):
+        for port in (0, 22, 80, 443, 1023, 65536, -1):
+            with self.assertRaises(ValueError):
+                _validate_port(port)
+
+
+class TestConnectRejectsTamperedFile(unittest.TestCase):
+    @patch("llmflux.slurm.connection._ping_endpoint")
+    @patch(
+        "llmflux.slurm.connection.read_connection_info",
+        return_value={**SAMPLE_INFO, "node": "169.254.169.254"},
+    )
+    def test_metadata_ip_returns_one_without_pinging(self, mock_read, mock_ping):
+        self.assertEqual(connect("99999"), 1)
+        mock_ping.assert_not_called()
+
+    @patch("llmflux.slurm.connection._ping_endpoint")
+    @patch(
+        "llmflux.slurm.connection.read_connection_info",
+        return_value={**SAMPLE_INFO, "node": "localhost"},
+    )
+    def test_localhost_returns_one_without_pinging(self, mock_read, mock_ping):
+        self.assertEqual(connect("99999"), 1)
+        mock_ping.assert_not_called()
+
+    @patch("llmflux.slurm.connection._ping_endpoint")
+    @patch(
+        "llmflux.slurm.connection.read_connection_info",
+        return_value={**SAMPLE_INFO, "port": 22},
+    )
+    def test_privileged_port_returns_one_without_pinging(self, mock_read, mock_ping):
+        self.assertEqual(connect("99999"), 1)
+        mock_ping.assert_not_called()
+
+    @patch(
+        "llmflux.slurm.connection.read_connection_info",
+        return_value={**SAMPLE_INFO, "node": "127.0.0.1"},
+    )
+    def test_error_message_mentions_tampering(self, mock_read):
+        stderr = StringIO()
+        with patch("sys.stderr", stderr):
+            connect("99999")
+        self.assertIn("tampered", stderr.getvalue())
 
 
 class TestConnect(unittest.TestCase):


### PR DESCRIPTION
llmflux connect used the node and port fields from connection.json verbatim to build an HTTP health-check request and a suggested ssh tunnel command. A tampered file could steer that request at internal targets (localhost:22, 169.254.169.254 cloud metadata) or inject ssh options via a hostname like -oProxyCommand=....

- connection.py: add _validate_node() — node must be an RFC 1123 hostname; reject localhost names, loopback/link-local/multicast/ unspecified/reserved IP literals, and (via the hostname pattern) IPv6 literals and option-injection strings. Sites can tighten this further with an LLMFLUX_NODE_PATTERN regex env var.
- connection.py: add _validate_port() — require 1024-65535, since engine servers always bind unprivileged ports; blocks probes at ssh/smtp/etc.
- connect() refuses (exit 1, no request sent) when validation fails.
- vllm.py/ollama.py: create the connection-file directories with umask 077 and chmod 700 ~/.llmflux, ~/.llmflux/serve, and the per-job dir, closing the TOCTOU window where another user could pre-plant a file in a loosely-permissioned serve/ directory.
- tests: cover accepted cluster hostnames/private IPs, rejected loopback/metadata/malformed values, port bounds, the env-var pattern, and connect() refusing tampered files without pinging.

Closes #109