### PR TITLE
remove hardcoded config workspace path and take from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ SLURM_ACCOUNT=                  # Your SLURM account with GPU access
 
 # Workspace root (default: current working directory)
 # All other directories, caches, and SLURM job files default to paths under this.
-# On HPC clusters, set this to a filesystem visible to compute nodes (e.g. /scratch/<user>/llmflux)
+# On HPC clusters, set this to a filesystem visible to compute nodes (e.g. /scratch/<project>/<user>/llmflux)
 LLMFLUX_WORKSPACE=
 
 # Base Directories (default: {workspace}/<name>, created automatically if missing)

--- a/.env.example
+++ b/.env.example
@@ -11,11 +11,18 @@ SLURM_ACCOUNT=                  # Your SLURM account with GPU access
 # These have defaults or can be overridden
 # ==============================================
 
-# Directory Structure (will be created automatically if not set)
-DATA_INPUT_DIR=data/input       # Default: data/input (for JSON input files)
-DATA_OUTPUT_DIR=data/output     # Default: data/output (for generated responses)
-MODELS_DIR=models              # Default: models (for model cache)
-LOGS_DIR=logs                 # Default: logs (for all log files)
+# Workspace root (default: current working directory)
+# All other directories, caches, and SLURM job files default to paths under this.
+# On HPC clusters, set this to a filesystem visible to compute nodes (e.g. /scratch/<user>/llmflux)
+LLMFLUX_WORKSPACE=
+
+# Base Directories (default: {workspace}/<name>, created automatically if missing)
+LLMFLUX_DATA_DIR=               # Default: {workspace}/data
+LLMFLUX_DATA_INPUT_DIR=         # Default: {LLMFLUX_DATA_DIR}/input (for JSON input files)
+LLMFLUX_DATA_OUTPUT_DIR=        # Default: {LLMFLUX_DATA_DIR}/output (for generated responses)
+LLMFLUX_MODELS_DIR=             # Default: {workspace}/models (for model cache)
+LLMFLUX_LOGS_DIR=               # Default: {workspace}/logs (for all log files)
+LLMFLUX_CONTAINERS_DIR=         # Default: {workspace}/containers (for Apptainer images)
 
 # Container Configuration
 CONTAINER_NAME=llm_processor    # Default: llm_processor (Apptainer container name)
@@ -49,7 +56,6 @@ VLLM_ENGINE_ARGS={"max-model-len":8192,"trust-remote-code":true}
 # 1. Only SLURM_ACCOUNT is required, everything else has defaults
 # 2. Directories will be created automatically if they don't exist
 # 3. Model-specific settings are in config/models/<model>/<size>.yaml
-# 4. All paths are relative to project root
+# 4. Unset directories default to paths under LLMFLUX_WORKSPACE
 # 5. Override any setting via environment variables when running
 # 6. Path precedence: code paths > environment variables > defaults
-# 7. If specifying paths in code, they override DATA_INPUT_DIR/DATA_OUTPUT_DIR 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same call was silently ignored by everything reading the derived paths. They
   are now derived from the configured directory attributes
   (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
-- Directory overrides now reach the Apptainer bind mounts. Path resolution and
-  the bind mounts were computed from two different sources, so an override
-  could change where the runner looked for input while the container was still
-  bound to the default location
+- `SlurmRunner.run()` resolved the input-file fallback and default output path
+  via `Config.get_path()`, while the Apptainer bind mounts used
+  `self.data_input_dir` / `self.data_output_dir` — two different reads of the
+  same config, so a `data_input_dir` / `data_output_dir` override could reach
+  one and not the other. Both now use `self.data_input_dir` /
+  `self.data_output_dir`
   (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 - `--mem` CLI flag and programmatic memory settings now actually reach the
   generated `#SBATCH --mem` line. Previously `SlurmConfig` had two fields for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+
+### Changed
+
+
 ### Fixed
 
 - `--mem` CLI flag and programmatic memory settings now actually reach the
@@ -19,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Breaking:** `Config.get_path()`, `Config.get_setting()`, `Config.default_paths`
+  and `Config.default_settings`. Directories are read directly from the
+  `Config` attributes (`data_input_dir`, `data_output_dir`, `models_dir`,
+  `logs_dir`, `containers_dir`); SLURM settings from `get_slurm_config()`.
+  As a consequence the unprefixed `DATA_INPUT_DIR` / `DATA_OUTPUT_DIR`
+  environment variables are no longer read — use `LLMFLUX_DATA_INPUT_DIR` and
+  `LLMFLUX_DATA_OUTPUT_DIR`.
 - **Breaking:** the duplicate `SlurmConfig.mem` field. Use
   `slurm_config.memory` instead. Note that `SlurmConfig(mem=...)` is silently
   ignored by pydantic, while attribute assignment (`slurm_config.mem = ...`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generated `#SBATCH --mem` line. Previously `SlurmConfig` had two fields for
   the same setting (`mem` and `memory`); the CLI and examples set `mem`, but
   the job scripts were built from `memory`, so user-specified memory was
-  silently ignored and jobs always got the `SLURM_MEM` env default (#119).
+  silently ignored and jobs always got the `SLURM_MEM` env default (see [#119](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/119)).
 - HuggingFace token for gated models is now also read from `HF_TOKEN` when
-  `HUGGINGFACE_TOKEN` is not set (#119).
+  `HUGGINGFACE_TOKEN` is not set (see [#119](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/119)).
 
 ### Removed
 
@@ -31,11 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `logs_dir`, `containers_dir`); SLURM settings from `get_slurm_config()`.
   As a consequence the unprefixed `DATA_INPUT_DIR` / `DATA_OUTPUT_DIR`
   environment variables are no longer read — use `LLMFLUX_DATA_INPUT_DIR` and
-  `LLMFLUX_DATA_OUTPUT_DIR`.
+  `LLMFLUX_DATA_OUTPUT_DIR` (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 - **Breaking:** the duplicate `SlurmConfig.mem` field. Use
   `slurm_config.memory` instead. Note that `SlurmConfig(mem=...)` is silently
   ignored by pydantic, while attribute assignment (`slurm_config.mem = ...`)
-  raises a `ValueError` (#119).
+  raises a `ValueError` (see [#119](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/119)).
 
 ## [1.0.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Configurable workspace via `LLMFLUX_WORKSPACE` or `workspace="/path"` on
+  `Config` / `ConfigManager.reset_config()`, resolved as code argument →
+  environment variable → current working directory. Every workspace-derived
+  path follows it: the `data`/`models`/`logs`/`containers` defaults, the
+  `.ollama` / `.vllm` engine homes, and the Apptainer `tmp` / `tmp/cache`
+  directories. Previously `Config.workspace` was hardcoded to the current
+  working directory, and the `WORKSPACE` variable named in the docs was never
+  read by any code. `workspace` is deliberately not accepted by
+  `update_config()`, since changing it on a live config would leave already
+  derived values stale — use `reset_config()`
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
+- Input and output directories are now configurable independently of
+  `data_dir`, via `LLMFLUX_DATA_INPUT_DIR` / `LLMFLUX_DATA_OUTPUT_DIR` or the
+  new `data_input_dir` / `data_output_dir` arguments on `Config`,
+  `reset_config()` and `update_config()`, defaulting to `{data_dir}/input` and
+  `{data_dir}/output`. This allows a read-only input location on one filesystem
+  and results written to another
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 
 ### Changed
 
+- All directory environment variables are now `LLMFLUX_`-prefixed
+  (`LLMFLUX_WORKSPACE`, `LLMFLUX_DATA_INPUT_DIR`, `LLMFLUX_DATA_OUTPUT_DIR`),
+  replacing the unprefixed `WORKSPACE` / `DATA_INPUT_DIR` / `DATA_OUTPUT_DIR`
+  names in `.env.example` and `docs/CONFIGURATION.md`
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
+- `SlurmRunner` resolves the input and output directories from the `Config`
+  attributes it already uses for the SLURM job environment and the Apptainer
+  bind mounts, instead of resolving them separately at use time
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 
 ### Fixed
 
+- `update_config()` no longer discards the directory overrides passed to it.
+  After applying its arguments it rebuilt `DATA_INPUT_DIR`, `DATA_OUTPUT_DIR`,
+  `MODELS_DIR`, `LOGS_DIR` and `CONTAINERS_DIR` from hardcoded
+  `config.workspace / ...` paths, so a `data_dir` or `models_dir` passed in the
+  same call was silently ignored by everything reading the derived paths. They
+  are now derived from the configured directory attributes
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
+- Directory overrides now reach the Apptainer bind mounts. Path resolution and
+  the bind mounts were computed from two different sources, so an override
+  could change where the runner looked for input while the container was still
+  bound to the default location
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 - `--mem` CLI flag and programmatic memory settings now actually reach the
   generated `#SBATCH --mem` line. Previously `SlurmConfig` had two fields for
   the same setting (`mem` and `memory`); the CLI and examples set `mem`, but
@@ -25,10 +64,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Breaking:** `Config.get_environment()`, which built a full environment
+  dictionary by iterating `default_paths` and `default_settings`. It had no
+  callers; `SlurmRunner` builds the job environment itself
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 - **Breaking:** `Config.get_path()`, `Config.get_setting()`, `Config.default_paths`
-  and `Config.default_settings`. Directories are read directly from the
-  `Config` attributes (`data_input_dir`, `data_output_dir`, `models_dir`,
-  `logs_dir`, `containers_dir`); SLURM settings from `get_slurm_config()`.
+  and `Config.default_settings`, the layer `get_environment()` was built on.
+  Directories are read directly from the `Config` attributes
+  (`data_input_dir`, `data_output_dir`, `models_dir`, `logs_dir`,
+  `containers_dir`); SLURM settings from `get_slurm_config()`.
   As a consequence the unprefixed `DATA_INPUT_DIR` / `DATA_OUTPUT_DIR`
   environment variables are no longer read — use `LLMFLUX_DATA_INPUT_DIR` and
   `LLMFLUX_DATA_OUTPUT_DIR` (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -45,9 +45,13 @@ The tables below show each parameter with its environment variable name, code se
 
 | Parameter | Environment Variable | Code Setting | Default | Description |
 |-----------|----------------------|-------------|---------|-------------|
-| Workspace | `WORKSPACE` | `workspace="/path/to/workspace"` in SlurmRunner | `./` | Project root directory |
-| Input directory | `DATA_INPUT_DIR` | Set via config | `data/input` | Directory for input files |
-| Output directory | `DATA_OUTPUT_DIR` | Set via config | `data/output` | Directory for output files |
+| Workspace | `LLMFLUX_WORKSPACE` | `workspace="/path/to/workspace"` in Config or SlurmRunner | `./` (current working directory) | Root directory for data, models, logs, containers, caches, and SLURM job files |
+| Data directory | `LLMFLUX_DATA_DIR` | `data_dir="/path"` in Config | `{workspace}/data` | Parent directory for input and output files |
+| Input directory | `LLMFLUX_DATA_INPUT_DIR` | `data_input_dir="/path"` in Config | `{data_dir}/input` | Directory for input files |
+| Output directory | `LLMFLUX_DATA_OUTPUT_DIR` | `data_output_dir="/path"` in Config | `{data_dir}/output` | Directory for generated responses |
+| Models directory | `LLMFLUX_MODELS_DIR` | `models_dir="/path"` in Config | `{workspace}/models` | Directory for model cache |
+| Logs directory | `LLMFLUX_LOGS_DIR` | `logs_dir="/path"` in Config | `{workspace}/logs` | Directory for log files |
+| Containers directory | `LLMFLUX_CONTAINERS_DIR` | `containers_dir="/path"` in Config | `{workspace}/containers` | Directory for Apptainer images |
 | HuggingFace cache | `HF_HOME` | Set via env | `{workspace}/.cache/huggingface` | Directory for HuggingFace model cache (used by vLLM) |
 
 ## Configuration Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmflux"
-version = "1.0.0"
+version = "2.0.0"
 description = "CLI tool for running LLM batch processing jobs on HPC systems"
 readme = "docs/README.md"
 license = {text = "MIT"}

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -208,7 +208,7 @@ class Config:
         self._load_env_file()
 
         # Initialize workspace paths
-        self.workspace = Path(workspace or os.getenv('LLMFLUX_WORKSPACE') or Path.cwd())
+        self.workspace = Path(workspace or os.getenv('LLMFLUX_WORKSPACE') or Path.cwd()).expanduser().resolve()
         
         # Set directories from parameters or environment variables
         self.data_dir = data_dir or os.getenv('LLMFLUX_DATA_DIR') or str(self.workspace / "data")

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -211,12 +211,12 @@ class Config:
         self.workspace = Path(workspace or os.getenv('LLMFLUX_WORKSPACE') or Path.cwd()).expanduser().resolve()
         
         # Set directories from parameters or environment variables
-        self.data_dir = data_dir or os.getenv('LLMFLUX_DATA_DIR') or str(self.workspace / "data")
-        self.data_input_dir = data_input_dir or os.getenv('LLMFLUX_DATA_INPUT_DIR') or str(Path(self.data_dir) / "input")
-        self.data_output_dir = data_output_dir or os.getenv('LLMFLUX_DATA_OUTPUT_DIR') or str(Path(self.data_dir) / "output")
-        self.models_dir = models_dir or os.getenv('LLMFLUX_MODELS_DIR') or str(self.workspace / "models")
-        self.logs_dir = logs_dir or os.getenv('LLMFLUX_LOGS_DIR') or str(self.workspace / "logs")
-        self.containers_dir = containers_dir or os.getenv('LLMFLUX_CONTAINERS_DIR') or str(self.workspace / "containers")
+        self.data_dir = str(Path(data_dir or os.getenv('LLMFLUX_DATA_DIR') or self.workspace / "data").expanduser().resolve())
+        self.data_input_dir = str(Path(data_input_dir or os.getenv('LLMFLUX_DATA_INPUT_DIR') or Path(self.data_dir) / "input").expanduser().resolve())
+        self.data_output_dir = str(Path(data_output_dir or os.getenv('LLMFLUX_DATA_OUTPUT_DIR') or Path(self.data_dir) / "output").expanduser().resolve())
+        self.models_dir = str(Path(models_dir or os.getenv('LLMFLUX_MODELS_DIR') or self.workspace / "models").expanduser().resolve())
+        self.logs_dir = str(Path(logs_dir or os.getenv('LLMFLUX_LOGS_DIR') or self.workspace / "logs").expanduser().resolve())
+        self.containers_dir = str(Path(containers_dir or os.getenv('LLMFLUX_CONTAINERS_DIR') or self.workspace / "containers").expanduser().resolve())
         
         # Set SLURM configuration
         self.slurm = slurm or SlurmConfig()

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -208,15 +208,15 @@ class Config:
         self._load_env_file()
 
         # Initialize workspace paths
-        self.workspace = Path(workspace or os.getenv('LLMFLUX_WORKSPACE') or Path.cwd()).expanduser().resolve()
-        
+        self.workspace = self._validate_dir(Path(workspace or os.getenv('LLMFLUX_WORKSPACE') or Path.cwd()).expanduser().resolve())
+
         # Set directories from parameters or environment variables
-        self.data_dir = str(Path(data_dir or os.getenv('LLMFLUX_DATA_DIR') or self.workspace / "data").expanduser().resolve())
-        self.data_input_dir = str(Path(data_input_dir or os.getenv('LLMFLUX_DATA_INPUT_DIR') or Path(self.data_dir) / "input").expanduser().resolve())
-        self.data_output_dir = str(Path(data_output_dir or os.getenv('LLMFLUX_DATA_OUTPUT_DIR') or Path(self.data_dir) / "output").expanduser().resolve())
-        self.models_dir = str(Path(models_dir or os.getenv('LLMFLUX_MODELS_DIR') or self.workspace / "models").expanduser().resolve())
-        self.logs_dir = str(Path(logs_dir or os.getenv('LLMFLUX_LOGS_DIR') or self.workspace / "logs").expanduser().resolve())
-        self.containers_dir = str(Path(containers_dir or os.getenv('LLMFLUX_CONTAINERS_DIR') or self.workspace / "containers").expanduser().resolve())
+        self.data_dir = str(self._validate_dir(Path(data_dir or os.getenv('LLMFLUX_DATA_DIR') or self.workspace / "data").expanduser().resolve()))
+        self.data_input_dir = str(self._validate_dir(Path(data_input_dir or os.getenv('LLMFLUX_DATA_INPUT_DIR') or Path(self.data_dir) / "input").expanduser().resolve()))
+        self.data_output_dir = str(self._validate_dir(Path(data_output_dir or os.getenv('LLMFLUX_DATA_OUTPUT_DIR') or Path(self.data_dir) / "output").expanduser().resolve()))
+        self.models_dir = str(self._validate_dir(Path(models_dir or os.getenv('LLMFLUX_MODELS_DIR') or self.workspace / "models").expanduser().resolve()))
+        self.logs_dir = str(self._validate_dir(Path(logs_dir or os.getenv('LLMFLUX_LOGS_DIR') or self.workspace / "logs").expanduser().resolve()))
+        self.containers_dir = str(self._validate_dir(Path(containers_dir or os.getenv('LLMFLUX_CONTAINERS_DIR') or self.workspace / "containers").expanduser().resolve()))
         
         # Set SLURM configuration
         self.slurm = slurm or SlurmConfig()
@@ -236,6 +236,26 @@ class Config:
                 engine="vllm",
                 home=str(self.workspace / ".vllm")
             )
+
+    def _validate_dir(self, path: Path) -> Path:
+        """Ensure a directory exists and is writable, creating it if necessary.
+
+        Args:
+            path: Directory path to validate
+
+        Returns:
+            The same path
+
+        Raises:
+            OSError: If the directory cannot be created or is not writable
+        """
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            if not os.access(path, os.W_OK):
+                raise PermissionError(f"Directory is not writable: {path}")
+        except (OSError, PermissionError) as e:
+            raise OSError(f"Cannot use directory '{path}': {e}") from e
+        return path
 
     def _load_env_file(self):
         """Load environment variables from .env file in project root."""

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -386,64 +386,6 @@ class Config:
             path.parent.mkdir(parents=True, exist_ok=True)
         return path
     
-    def get_environment(self, overrides: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
-        """Get a complete environment dictionary with all settings.
-        
-        Args:
-            overrides: Optional dictionary of override values
-            
-        Returns:
-            Dictionary of environment variables
-        """
-        # Start with current environment
-        env = os.environ.copy()
-        
-        # Add all paths
-        for path_name in self.default_paths:
-            code_path = overrides.get(path_name) if overrides else None
-            env[path_name] = str(self.get_path(path_name, code_path))
-        
-        # Add all settings
-        for setting_name in self.default_settings:
-            code_value = overrides.get(setting_name) if overrides else None
-            env[setting_name] = str(self.get_setting(setting_name, code_value))
-        
-        # Add SLURM config
-        # Create a filtered dictionary with SLURM-specific overrides
-        slurm_overrides = {}
-        if overrides:
-            # Map SLURM_* keys to their corresponding field names in SlurmConfig
-            slurm_field_mapping = {
-                'SLURM_ACCOUNT': 'account',
-                'SLURM_PARTITION': 'partition',
-                'SLURM_NODES': 'nodes',
-                'SLURM_GPUS_PER_NODE': 'gpus_per_node',
-                'SLURM_TIME': 'time',
-                'SLURM_MEM': 'memory',
-                'SLURM_CPUS_PER_TASK': 'cpus_per_task'
-            }
-            
-            for env_key, field_name in slurm_field_mapping.items():
-                if env_key in overrides:
-                    slurm_overrides[field_name] = overrides[env_key]
-        
-        slurm_config = self.get_slurm_config(slurm_overrides)
-        env.update({
-            'SLURM_ACCOUNT': slurm_config.account,
-            'SLURM_PARTITION': slurm_config.partition,
-            'SLURM_NODES': str(slurm_config.nodes),
-            'SLURM_GPUS_PER_NODE': str(slurm_config.gpus_per_node),
-            'SLURM_TIME': slurm_config.time,
-            'SLURM_MEM': slurm_config.memory,
-            'SLURM_CPUS_PER_TASK': str(slurm_config.cpus_per_task),
-            'VLLM_ORIGINS': self.engine.origins,
-            'VLLM_INSECURE': self.engine.insecure,
-            'VLLM_HOME': self.engine.home,
-        })
-        
-        # Filter out None values
-        return {k: v for k, v in env.items() if v is not None}
-    
     def load_model_config(
         self,
         model_key: str,

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -284,6 +284,7 @@ class Config:
         2. Variables from .env file (middle priority)
         3. Default values (lowest priority)
         """
+        logging.info(f"Loading environment variables from {env_file}")
         try:
             with open(env_file, 'r') as f:
                 for line in f:
@@ -307,7 +308,6 @@ class Config:
                             os.environ[key] = value
         except Exception as e:
             # Log the error but continue execution
-            import logging
             logging.warning(f"Error loading .env file: {str(e)}")
             pass
     

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -3,7 +3,7 @@ import os
 import re
 import json
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Union
+from typing import Dict, Any, List, Optional
 import yaml
 import logging
 from pydantic import BaseModel, Field, field_validator
@@ -237,36 +237,6 @@ class Config:
                 home=str(self.workspace / ".vllm")
             )
 
-        # Define default paths
-        self.default_paths = {
-            'DATA_INPUT_DIR': Path(self.data_input_dir),
-            'DATA_OUTPUT_DIR': Path(self.data_output_dir),
-            'MODELS_DIR': Path(self.models_dir),
-            'LOGS_DIR': Path(self.logs_dir),
-            'CONTAINERS_DIR': Path(self.containers_dir),
-            'APPTAINER_TMPDIR': self.workspace / "tmp",
-            'APPTAINER_CACHEDIR': self.workspace / "tmp" / "cache",
-            'OLLAMA_HOME': self.workspace / ".ollama",
-            'VLLM_HOME': self.workspace / ".vllm",
-        }
-        
-        # Define default settings
-        self.default_settings = {
-            'SLURM_PARTITION': self.slurm.partition,
-            'SLURM_NODES': str(self.slurm.nodes),
-            'SLURM_GPUS_PER_NODE': str(self.slurm.gpus_per_node),
-            'SLURM_TIME': self.slurm.time,
-            'SLURM_MEM': self.slurm.memory,
-            'SLURM_CPUS_PER_TASK': str(self.slurm.cpus_per_task),
-            'OLLAMA_ORIGINS': '*',
-            'OLLAMA_INSECURE': 'true',
-            'CURL_CA_BUNDLE': '',
-            'SSL_CERT_FILE': '',
-            'VLLM_ORIGINS': '*',
-            'VLLM_INSECURE': 'true',
-            'VLLM_HOME': self.workspace / ".vllm",
-        }
-    
     def _load_env_file(self):
         """Load environment variables from .env file in project root."""
         # Try to find .env file in current directory or parent directories
@@ -320,56 +290,6 @@ class Config:
             import logging
             logging.warning(f"Error loading .env file: {str(e)}")
             pass
-    
-    def get_path(self, path_name: str, code_path: Optional[Union[str, Path]] = None) -> Path:
-        """Get a resolved path following precedence: code path > env var > default.
-        
-        Args:
-            path_name: Name of the path (e.g., 'DATA_INPUT_DIR')
-            code_path: Optional explicit path from code
-            
-        Returns:
-            Resolved Path object
-        """
-        # 1. Code path (highest priority)
-        if code_path is not None:
-            return Path(code_path)
-        
-        # 2. Environment variable (middle priority)
-        if path_name in os.environ and os.environ[path_name]:
-            return Path(os.environ[path_name])
-        
-        # 3. Default value (lowest priority)
-        if path_name in self.default_paths:
-            return self.default_paths[path_name]
-        
-        # Fallback to workspace if no match
-        return self.workspace / path_name.lower()
-    
-    def get_setting(self, setting_name: str, code_value: Optional[Any] = None) -> Any:
-        """Get a resolved setting following precedence: code value > env var > default.
-        
-        Args:
-            setting_name: Name of the setting (e.g., 'SLURM_PARTITION')
-            code_value: Optional explicit value from code
-            
-        Returns:
-            Resolved setting value
-        """
-        # 1. Code value (highest priority)
-        if code_value is not None:
-            return code_value
-        
-        # 2. Environment variable (middle priority)
-        if setting_name in os.environ and os.environ[setting_name]:
-            return os.environ[setting_name]
-        
-        # 3. Default value (lowest priority)
-        if setting_name in self.default_settings:
-            return self.default_settings[setting_name]
-        
-        # Return None if no match
-        return None
     
     def ensure_directory(self, path: Path) -> Path:
         """Ensure a directory exists.

--- a/src/llmflux/core/config.py
+++ b/src/llmflux/core/config.py
@@ -176,8 +176,11 @@ def parse_gpu_memory(memory_str: str) -> int:
 class Config:
     """Central configuration management."""
     
-    def __init__(self, 
+    def __init__(self,
+                 workspace: Optional[str] = None,
                  data_dir: Optional[str] = None,
+                 data_input_dir: Optional[str] = None,
+                 data_output_dir: Optional[str] = None,
                  models_dir: Optional[str] = None,
                  logs_dir: Optional[str] = None,
                  containers_dir: Optional[str] = None,
@@ -185,9 +188,12 @@ class Config:
                  models: Optional[List[ModelConfig]] = None,
                  engine: Optional[str] = None):
         """Initialize configuration.
-        
+
         Args:
+            workspace: Optional path to workspace directory (defaults to current working directory)
             data_dir: Optional path to data directory
+            data_input_dir: Optional path to input directory (defaults to {data_dir}/input)
+            data_output_dir: Optional path to output directory (defaults to {data_dir}/output)
             models_dir: Optional path to models directory
             logs_dir: Optional path to logs directory
             containers_dir: Optional path to containers directory
@@ -197,15 +203,17 @@ class Config:
         """
         self.package_dir = Path(__file__).parent.parent
         self.templates_dir = self.package_dir / 'templates'
-        
+
         # Load environment variables from .env file if it exists
         self._load_env_file()
-        
+
         # Initialize workspace paths
-        self.workspace = Path.cwd()
+        self.workspace = Path(workspace or os.getenv('LLMFLUX_WORKSPACE') or Path.cwd())
         
         # Set directories from parameters or environment variables
         self.data_dir = data_dir or os.getenv('LLMFLUX_DATA_DIR') or str(self.workspace / "data")
+        self.data_input_dir = data_input_dir or os.getenv('LLMFLUX_DATA_INPUT_DIR') or str(Path(self.data_dir) / "input")
+        self.data_output_dir = data_output_dir or os.getenv('LLMFLUX_DATA_OUTPUT_DIR') or str(Path(self.data_dir) / "output")
         self.models_dir = models_dir or os.getenv('LLMFLUX_MODELS_DIR') or str(self.workspace / "models")
         self.logs_dir = logs_dir or os.getenv('LLMFLUX_LOGS_DIR') or str(self.workspace / "logs")
         self.containers_dir = containers_dir or os.getenv('LLMFLUX_CONTAINERS_DIR') or str(self.workspace / "containers")
@@ -231,8 +239,8 @@ class Config:
 
         # Define default paths
         self.default_paths = {
-            'DATA_INPUT_DIR': Path(self.data_dir) / "input",
-            'DATA_OUTPUT_DIR': Path(self.data_dir) / "output",
+            'DATA_INPUT_DIR': Path(self.data_input_dir),
+            'DATA_OUTPUT_DIR': Path(self.data_output_dir),
             'MODELS_DIR': Path(self.models_dir),
             'LOGS_DIR': Path(self.logs_dir),
             'CONTAINERS_DIR': Path(self.containers_dir),

--- a/src/llmflux/core/config_manager.py
+++ b/src/llmflux/core/config_manager.py
@@ -2,6 +2,7 @@
 """Configuration Manager for LLMFlux."""
 
 from typing import Optional, Dict, Any, List
+from pathlib import Path
 from .config import Config, ModelConfig, SlurmConfig, EngineConfig
 import os
 
@@ -156,11 +157,11 @@ class ConfigManager:
         
         # Update the derived paths
         config.default_paths.update({
-            'DATA_INPUT_DIR': config.workspace / "data" / "input",
-            'DATA_OUTPUT_DIR': config.workspace / "data" / "output",
-            'MODELS_DIR': config.workspace / "models",
-            'LOGS_DIR': config.workspace / "logs",
-            'CONTAINERS_DIR': config.workspace / "containers",
+            'DATA_INPUT_DIR': Path(config.data_dir) / "input",
+            'DATA_OUTPUT_DIR': Path(config.data_dir) / "output",
+            'MODELS_DIR': Path(config.models_dir),
+            'LOGS_DIR': Path(config.logs_dir),
+            'CONTAINERS_DIR': Path(config.containers_dir),
         })
         
         return config 

--- a/src/llmflux/core/config_manager.py
+++ b/src/llmflux/core/config_manager.py
@@ -154,21 +154,21 @@ class ConfigManager:
         
         # Update only the provided values
         if data_dir:
-            config.data_dir = data_dir
+            config.data_dir = str(Path(data_dir).expanduser().resolve())
             # Re-derive input/output so they follow the new data_dir unless
             # explicitly overridden below
-            config.data_input_dir = str(Path(data_dir) / "input")
-            config.data_output_dir = str(Path(data_dir) / "output")
+            config.data_input_dir = str(Path(config.data_dir) / "input")
+            config.data_output_dir = str(Path(config.data_dir) / "output")
         if data_input_dir:
-            config.data_input_dir = data_input_dir
+            config.data_input_dir = str(Path(data_input_dir).expanduser().resolve())
         if data_output_dir:
-            config.data_output_dir = data_output_dir
+            config.data_output_dir = str(Path(data_output_dir).expanduser().resolve())
         if models_dir:
-            config.models_dir = models_dir
+            config.models_dir = str(Path(models_dir).expanduser().resolve())
         if logs_dir:
-            config.logs_dir = logs_dir
+            config.logs_dir = str(Path(logs_dir).expanduser().resolve())
         if containers_dir:
-            config.containers_dir = containers_dir
+            config.containers_dir = str(Path(containers_dir).expanduser().resolve())
         if slurm:
             config.slurm = slurm
         if models:

--- a/src/llmflux/core/config_manager.py
+++ b/src/llmflux/core/config_manager.py
@@ -80,7 +80,10 @@ class ConfigManager:
         return default
     
     @staticmethod
-    def reset_config(data_dir: Optional[str] = None,
+    def reset_config(workspace: Optional[str] = None,
+                     data_dir: Optional[str] = None,
+                     data_input_dir: Optional[str] = None,
+                     data_output_dir: Optional[str] = None,
                      models_dir: Optional[str] = None,
                      logs_dir: Optional[str] = None,
                      containers_dir: Optional[str] = None,
@@ -88,22 +91,28 @@ class ConfigManager:
                      models: Optional[List[ModelConfig]] = None,
                      engine: Optional[EngineConfig] = None) -> Config:
         """Reset the singleton Config instance with new values.
-        
+
         Args:
+            workspace: Optional path to workspace directory (defaults to current working directory)
             data_dir: Optional path to data directory
+            data_input_dir: Optional path to input directory (defaults to {data_dir}/input)
+            data_output_dir: Optional path to output directory (defaults to {data_dir}/output)
             models_dir: Optional path to models directory
             logs_dir: Optional path to logs directory
             containers_dir: Optional path to containers directory
             slurm: Optional SLURM configuration
             models: Optional list of model configurations
             engine: Whether to use VLLM or OLLAMA
-            
+
         Returns:
             Config: The new singleton Config instance
         """
         global _config_instance
         _config_instance = Config(
+            workspace=workspace,
             data_dir=data_dir,
+            data_input_dir=data_input_dir,
+            data_output_dir=data_output_dir,
             models_dir=models_dir,
             logs_dir=logs_dir,
             containers_dir=containers_dir,
@@ -115,6 +124,8 @@ class ConfigManager:
     
     @staticmethod
     def update_config(data_dir: Optional[str] = None,
+                      data_input_dir: Optional[str] = None,
+                      data_output_dir: Optional[str] = None,
                       models_dir: Optional[str] = None,
                       logs_dir: Optional[str] = None,
                       containers_dir: Optional[str] = None,
@@ -122,11 +133,13 @@ class ConfigManager:
                       models: Optional[List[ModelConfig]] = None,
                       engine: Optional[EngineConfig] = None) -> Config:
         """Update the singleton Config instance with new values.
-        
+
         Only updates the provided values, keeping the rest unchanged.
-        
+
         Args:
             data_dir: Optional path to data directory
+            data_input_dir: Optional path to input directory (defaults to {data_dir}/input)
+            data_output_dir: Optional path to output directory (defaults to {data_dir}/output)
             models_dir: Optional path to models directory
             logs_dir: Optional path to logs directory
             containers_dir: Optional path to containers directory
@@ -142,6 +155,14 @@ class ConfigManager:
         # Update only the provided values
         if data_dir:
             config.data_dir = data_dir
+            # Re-derive input/output so they follow the new data_dir unless
+            # explicitly overridden below
+            config.data_input_dir = str(Path(data_dir) / "input")
+            config.data_output_dir = str(Path(data_dir) / "output")
+        if data_input_dir:
+            config.data_input_dir = data_input_dir
+        if data_output_dir:
+            config.data_output_dir = data_output_dir
         if models_dir:
             config.models_dir = models_dir
         if logs_dir:
@@ -157,8 +178,8 @@ class ConfigManager:
         
         # Update the derived paths
         config.default_paths.update({
-            'DATA_INPUT_DIR': Path(config.data_dir) / "input",
-            'DATA_OUTPUT_DIR': Path(config.data_dir) / "output",
+            'DATA_INPUT_DIR': Path(config.data_input_dir),
+            'DATA_OUTPUT_DIR': Path(config.data_output_dir),
             'MODELS_DIR': Path(config.models_dir),
             'LOGS_DIR': Path(config.logs_dir),
             'CONTAINERS_DIR': Path(config.containers_dir),

--- a/src/llmflux/core/config_manager.py
+++ b/src/llmflux/core/config_manager.py
@@ -175,14 +175,5 @@ class ConfigManager:
             config.models = models
         if engine:
             config.engine = engine
-        
-        # Update the derived paths
-        config.default_paths.update({
-            'DATA_INPUT_DIR': Path(config.data_input_dir),
-            'DATA_OUTPUT_DIR': Path(config.data_output_dir),
-            'MODELS_DIR': Path(config.models_dir),
-            'LOGS_DIR': Path(config.logs_dir),
-            'CONTAINERS_DIR': Path(config.containers_dir),
-        })
-        
-        return config 
+
+        return config

--- a/src/llmflux/slurm/runner.py
+++ b/src/llmflux/slurm/runner.py
@@ -425,7 +425,7 @@ class SlurmRunner:
         # Add additional parameters from kwargs through config manager
         for key, value in kwargs.items():
             # Skip parameters that are already handled
-            if key in ['model', 'batch_size', 'save_frequency', 'vllm_engine_args']:
+            if key in ['model', 'batch_size', 'save_frequency', 'vllm_engine_args', 'custom_config_path']:
                 continue
                 
             # Use config manager to get the value with proper priority

--- a/src/llmflux/slurm/runner.py
+++ b/src/llmflux/slurm/runner.py
@@ -277,9 +277,7 @@ class SlurmRunner:
 
         if not input_file.exists():
             # If it doesn't exist, check if it's relative to the data input directory
-            config = self.config_manager.get_config()
-            data_input_dir = config.get_path('DATA_INPUT_DIR')
-            potential_path = data_input_dir / input_file.name
+            potential_path = self.data_input_dir / input_file.name
             if potential_path.exists():
                 input_file = potential_path
             else:
@@ -291,9 +289,7 @@ class SlurmRunner:
         if output_path:
             output_file = Path(output_path).resolve()
         else:
-            config = self.config_manager.get_config()
-            output_dir = config.get_path('DATA_OUTPUT_DIR')
-            output_file = output_dir / f"results_{int(time.time())}.json"
+            output_file = self.data_output_dir / f"results_{int(time.time())}.json"
         
         # Ensure directories exist
         config = self.config_manager.get_config()

--- a/src/llmflux/slurm/runner.py
+++ b/src/llmflux/slurm/runner.py
@@ -48,7 +48,7 @@ class SlurmRunner:
         self.slurm_config = config or self.config_manager.get_config().get_slurm_config()
         
         # Set workspace
-        self.workspace = Path(workspace) if workspace else Path(self.config_manager.get_config().workspace)
+        self.workspace = Path(workspace).expanduser().resolve() if workspace else Path(self.config_manager.get_config().workspace)
         
         # Get paths from config if available
         config = self.config_manager.get_config()
@@ -296,17 +296,19 @@ class SlurmRunner:
         config.ensure_directory(input_file.parent if input_file.is_file() else input_file)
         config.ensure_directory(output_file.parent)
         
-        # Copy input to workspace if needed
-        if not input_file.is_relative_to(self.workspace) and input_file.exists():
+        # Copy input into the data input dir only if the job can't already see it
+        already_visible = (
+            input_file.is_relative_to(self.workspace)
+            or input_file.is_relative_to(self.data_input_dir)
+        )
+        if not already_visible and input_file.exists():
+            if input_file.is_dir():
+                raise ValueError(
+                    f"Input must be a JSONL file, got a directory: {input_file}"
+                )
             workspace_input = self.data_input_dir / input_file.name
-            if input_file.is_file():
-                workspace_input.parent.mkdir(parents=True, exist_ok=True)
-                workspace_input.write_bytes(input_file.read_bytes())
-            else:
-                # If directory exists, remove it first to avoid FileExistsError
-                if workspace_input.exists():
-                    shutil.rmtree(workspace_input)
-                shutil.copytree(input_file, workspace_input)
+            workspace_input.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(input_file, workspace_input)
             input_file = workspace_input
         
         # Setup environment

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -138,6 +138,82 @@ class TestConfigDirectoryResolution(unittest.TestCase):
         self.assertEqual(cfg.data_dir, "/tmp/explicit")
 
 
+class TestConfigWorkspace(unittest.TestCase):
+    def test_default_workspace_is_cwd(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LLMFLUX_WORKSPACE", None)
+            cfg = Config()
+        self.assertEqual(cfg.workspace, Path.cwd())
+
+    def test_explicit_workspace_used(self):
+        cfg = Config(workspace="/tmp/myworkspace")
+        self.assertEqual(cfg.workspace, Path("/tmp/myworkspace"))
+
+    def test_env_var_workspace_used(self):
+        with patch.dict(os.environ, {"LLMFLUX_WORKSPACE": "/tmp/envworkspace"}):
+            cfg = Config()
+        self.assertEqual(cfg.workspace, Path("/tmp/envworkspace"))
+
+    def test_code_param_beats_env_var(self):
+        with patch.dict(os.environ, {"LLMFLUX_WORKSPACE": "/tmp/envworkspace"}):
+            cfg = Config(workspace="/tmp/explicit")
+        self.assertEqual(cfg.workspace, Path("/tmp/explicit"))
+
+    def test_directories_derive_from_workspace(self):
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("LLMFLUX_DATA_DIR", "LLMFLUX_MODELS_DIR", "LLMFLUX_LOGS_DIR", "LLMFLUX_CONTAINERS_DIR"):
+                os.environ.pop(var, None)
+            cfg = Config(workspace="/tmp/myworkspace")
+        self.assertEqual(cfg.data_dir, "/tmp/myworkspace/data")
+        self.assertEqual(cfg.models_dir, "/tmp/myworkspace/models")
+        self.assertEqual(cfg.logs_dir, "/tmp/myworkspace/logs")
+        self.assertEqual(cfg.containers_dir, "/tmp/myworkspace/containers")
+        self.assertEqual(cfg.default_paths["APPTAINER_TMPDIR"], Path("/tmp/myworkspace/tmp"))
+
+    def test_explicit_dir_beats_workspace_derived_default(self):
+        with patch.dict(os.environ, {"LLMFLUX_DATA_DIR": "/tmp/envdata"}):
+            cfg = Config(workspace="/tmp/myworkspace")
+        self.assertEqual(cfg.data_dir, "/tmp/envdata")
+
+
+class TestConfigInputOutputDirs(unittest.TestCase):
+    def test_default_derive_from_data_dir(self):
+        cfg = Config(data_dir="/tmp/mydata")
+        self.assertEqual(cfg.data_input_dir, "/tmp/mydata/input")
+        self.assertEqual(cfg.data_output_dir, "/tmp/mydata/output")
+        self.assertEqual(cfg.default_paths["DATA_INPUT_DIR"], Path("/tmp/mydata/input"))
+        self.assertEqual(cfg.default_paths["DATA_OUTPUT_DIR"], Path("/tmp/mydata/output"))
+
+    def test_explicit_separate_input_output(self):
+        cfg = Config(data_input_dir="/projects/prompts", data_output_dir="/scratch/results")
+        self.assertEqual(cfg.data_input_dir, "/projects/prompts")
+        self.assertEqual(cfg.data_output_dir, "/scratch/results")
+        self.assertEqual(cfg.default_paths["DATA_INPUT_DIR"], Path("/projects/prompts"))
+        self.assertEqual(cfg.default_paths["DATA_OUTPUT_DIR"], Path("/scratch/results"))
+
+    def test_env_var_input_output(self):
+        with patch.dict(os.environ, {
+            "LLMFLUX_DATA_INPUT_DIR": "/env/inputs",
+            "LLMFLUX_DATA_OUTPUT_DIR": "/env/outputs",
+        }):
+            cfg = Config()
+        self.assertEqual(cfg.data_input_dir, "/env/inputs")
+        self.assertEqual(cfg.data_output_dir, "/env/outputs")
+
+    def test_code_param_beats_env_var(self):
+        with patch.dict(os.environ, {"LLMFLUX_DATA_INPUT_DIR": "/env/inputs"}):
+            cfg = Config(data_input_dir="/explicit/inputs")
+        self.assertEqual(cfg.data_input_dir, "/explicit/inputs")
+
+    def test_get_path_reflects_explicit_dirs(self):
+        cfg = Config(data_input_dir="/projects/prompts", data_output_dir="/scratch/results")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DATA_INPUT_DIR", None)
+            os.environ.pop("DATA_OUTPUT_DIR", None)
+            self.assertEqual(cfg.get_path("DATA_INPUT_DIR"), Path("/projects/prompts"))
+            self.assertEqual(cfg.get_path("DATA_OUTPUT_DIR"), Path("/scratch/results"))
+
+
 class TestConfigGetPath(unittest.TestCase):
     def setUp(self):
         self.cfg = Config(data_dir="/tmp/data", logs_dir="/tmp/logs")

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -115,12 +115,12 @@ class TestValidationConfig(unittest.TestCase):
 class TestConfigDirectoryResolution(unittest.TestCase):
     def test_explicit_data_dir_used(self):
         cfg = Config(data_dir="/tmp/mydata")
-        self.assertEqual(cfg.data_dir, "/tmp/mydata")
+        self.assertEqual(cfg.data_dir, str(Path("/tmp/mydata").resolve()))
 
     def test_env_var_data_dir_used(self):
         with patch.dict(os.environ, {"LLMFLUX_DATA_DIR": "/tmp/envdata"}):
             cfg = Config()
-        self.assertEqual(cfg.data_dir, "/tmp/envdata")
+        self.assertEqual(cfg.data_dir, str(Path("/tmp/envdata").resolve()))
 
     def test_default_data_dir_is_cwd_relative(self):
         with patch.dict(os.environ, {}, clear=False):
@@ -130,12 +130,12 @@ class TestConfigDirectoryResolution(unittest.TestCase):
 
     def test_explicit_logs_dir(self):
         cfg = Config(logs_dir="/tmp/mylogs")
-        self.assertEqual(cfg.logs_dir, "/tmp/mylogs")
+        self.assertEqual(cfg.logs_dir, str(Path("/tmp/mylogs").resolve()))
 
     def test_code_param_beats_env_var(self):
         with patch.dict(os.environ, {"LLMFLUX_DATA_DIR": "/tmp/envdata"}):
             cfg = Config(data_dir="/tmp/explicit")
-        self.assertEqual(cfg.data_dir, "/tmp/explicit")
+        self.assertEqual(cfg.data_dir, str(Path("/tmp/explicit").resolve()))
 
 
 class TestConfigWorkspace(unittest.TestCase):
@@ -147,58 +147,60 @@ class TestConfigWorkspace(unittest.TestCase):
 
     def test_explicit_workspace_used(self):
         cfg = Config(workspace="/tmp/myworkspace")
-        self.assertEqual(cfg.workspace, Path("/tmp/myworkspace"))
+        self.assertEqual(cfg.workspace, Path("/tmp/myworkspace").resolve())
 
     def test_env_var_workspace_used(self):
         with patch.dict(os.environ, {"LLMFLUX_WORKSPACE": "/tmp/envworkspace"}):
             cfg = Config()
-        self.assertEqual(cfg.workspace, Path("/tmp/envworkspace"))
+        self.assertEqual(cfg.workspace, Path("/tmp/envworkspace").resolve())
 
     def test_code_param_beats_env_var(self):
         with patch.dict(os.environ, {"LLMFLUX_WORKSPACE": "/tmp/envworkspace"}):
             cfg = Config(workspace="/tmp/explicit")
-        self.assertEqual(cfg.workspace, Path("/tmp/explicit"))
+        self.assertEqual(cfg.workspace, Path("/tmp/explicit").resolve())
 
     def test_directories_derive_from_workspace(self):
         with patch.dict(os.environ, {}, clear=False):
             for var in ("LLMFLUX_DATA_DIR", "LLMFLUX_MODELS_DIR", "LLMFLUX_LOGS_DIR", "LLMFLUX_CONTAINERS_DIR"):
                 os.environ.pop(var, None)
             cfg = Config(workspace="/tmp/myworkspace")
-        self.assertEqual(cfg.data_dir, "/tmp/myworkspace/data")
-        self.assertEqual(cfg.models_dir, "/tmp/myworkspace/models")
-        self.assertEqual(cfg.logs_dir, "/tmp/myworkspace/logs")
-        self.assertEqual(cfg.containers_dir, "/tmp/myworkspace/containers")
+        workspace = str(Path("/tmp/myworkspace").resolve())
+        self.assertEqual(cfg.data_dir, f"{workspace}/data")
+        self.assertEqual(cfg.models_dir, f"{workspace}/models")
+        self.assertEqual(cfg.logs_dir, f"{workspace}/logs")
+        self.assertEqual(cfg.containers_dir, f"{workspace}/containers")
 
     def test_explicit_dir_beats_workspace_derived_default(self):
         with patch.dict(os.environ, {"LLMFLUX_DATA_DIR": "/tmp/envdata"}):
             cfg = Config(workspace="/tmp/myworkspace")
-        self.assertEqual(cfg.data_dir, "/tmp/envdata")
+        self.assertEqual(cfg.data_dir, str(Path("/tmp/envdata").resolve()))
 
 
 class TestConfigInputOutputDirs(unittest.TestCase):
     def test_default_derive_from_data_dir(self):
         cfg = Config(data_dir="/tmp/mydata")
-        self.assertEqual(cfg.data_input_dir, "/tmp/mydata/input")
-        self.assertEqual(cfg.data_output_dir, "/tmp/mydata/output")
+        data_dir = str(Path("/tmp/mydata").resolve())
+        self.assertEqual(cfg.data_input_dir, f"{data_dir}/input")
+        self.assertEqual(cfg.data_output_dir, f"{data_dir}/output")
 
     def test_explicit_separate_input_output(self):
-        cfg = Config(data_input_dir="/projects/prompts", data_output_dir="/scratch/results")
-        self.assertEqual(cfg.data_input_dir, "/projects/prompts")
-        self.assertEqual(cfg.data_output_dir, "/scratch/results")
+        cfg = Config(data_input_dir="/tmp/projects/prompts", data_output_dir="/tmp/scratch/results")
+        self.assertEqual(cfg.data_input_dir, str(Path("/tmp/projects/prompts").resolve()))
+        self.assertEqual(cfg.data_output_dir, str(Path("/tmp/scratch/results").resolve()))
 
     def test_env_var_input_output(self):
         with patch.dict(os.environ, {
-            "LLMFLUX_DATA_INPUT_DIR": "/env/inputs",
-            "LLMFLUX_DATA_OUTPUT_DIR": "/env/outputs",
+            "LLMFLUX_DATA_INPUT_DIR": "/tmp/env/inputs",
+            "LLMFLUX_DATA_OUTPUT_DIR": "/tmp/env/outputs",
         }):
             cfg = Config()
-        self.assertEqual(cfg.data_input_dir, "/env/inputs")
-        self.assertEqual(cfg.data_output_dir, "/env/outputs")
+        self.assertEqual(cfg.data_input_dir, str(Path("/tmp/env/inputs").resolve()))
+        self.assertEqual(cfg.data_output_dir, str(Path("/tmp/env/outputs").resolve()))
 
     def test_code_param_beats_env_var(self):
-        with patch.dict(os.environ, {"LLMFLUX_DATA_INPUT_DIR": "/env/inputs"}):
-            cfg = Config(data_input_dir="/explicit/inputs")
-        self.assertEqual(cfg.data_input_dir, "/explicit/inputs")
+        with patch.dict(os.environ, {"LLMFLUX_DATA_INPUT_DIR": "/tmp/env/inputs"}):
+            cfg = Config(data_input_dir="/tmp/explicit/inputs")
+        self.assertEqual(cfg.data_input_dir, str(Path("/tmp/explicit/inputs").resolve()))
 
     def test_legacy_unprefixed_env_vars_are_ignored(self):
         # DATA_INPUT_DIR/DATA_OUTPUT_DIR are no longer read by any config code;
@@ -210,8 +212,9 @@ class TestConfigInputOutputDirs(unittest.TestCase):
             os.environ.pop("LLMFLUX_DATA_INPUT_DIR", None)
             os.environ.pop("LLMFLUX_DATA_OUTPUT_DIR", None)
             cfg = Config(data_dir="/tmp/mydata")
-        self.assertEqual(cfg.data_input_dir, "/tmp/mydata/input")
-        self.assertEqual(cfg.data_output_dir, "/tmp/mydata/output")
+        data_dir = str(Path("/tmp/mydata").resolve())
+        self.assertEqual(cfg.data_input_dir, f"{data_dir}/input")
+        self.assertEqual(cfg.data_output_dir, f"{data_dir}/output")
 
 
 class TestGetSlurmConfigMemory(unittest.TestCase):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -168,7 +168,6 @@ class TestConfigWorkspace(unittest.TestCase):
         self.assertEqual(cfg.models_dir, "/tmp/myworkspace/models")
         self.assertEqual(cfg.logs_dir, "/tmp/myworkspace/logs")
         self.assertEqual(cfg.containers_dir, "/tmp/myworkspace/containers")
-        self.assertEqual(cfg.default_paths["APPTAINER_TMPDIR"], Path("/tmp/myworkspace/tmp"))
 
     def test_explicit_dir_beats_workspace_derived_default(self):
         with patch.dict(os.environ, {"LLMFLUX_DATA_DIR": "/tmp/envdata"}):
@@ -181,15 +180,11 @@ class TestConfigInputOutputDirs(unittest.TestCase):
         cfg = Config(data_dir="/tmp/mydata")
         self.assertEqual(cfg.data_input_dir, "/tmp/mydata/input")
         self.assertEqual(cfg.data_output_dir, "/tmp/mydata/output")
-        self.assertEqual(cfg.default_paths["DATA_INPUT_DIR"], Path("/tmp/mydata/input"))
-        self.assertEqual(cfg.default_paths["DATA_OUTPUT_DIR"], Path("/tmp/mydata/output"))
 
     def test_explicit_separate_input_output(self):
         cfg = Config(data_input_dir="/projects/prompts", data_output_dir="/scratch/results")
         self.assertEqual(cfg.data_input_dir, "/projects/prompts")
         self.assertEqual(cfg.data_output_dir, "/scratch/results")
-        self.assertEqual(cfg.default_paths["DATA_INPUT_DIR"], Path("/projects/prompts"))
-        self.assertEqual(cfg.default_paths["DATA_OUTPUT_DIR"], Path("/scratch/results"))
 
     def test_env_var_input_output(self):
         with patch.dict(os.environ, {
@@ -205,65 +200,18 @@ class TestConfigInputOutputDirs(unittest.TestCase):
             cfg = Config(data_input_dir="/explicit/inputs")
         self.assertEqual(cfg.data_input_dir, "/explicit/inputs")
 
-    def test_get_path_reflects_explicit_dirs(self):
-        cfg = Config(data_input_dir="/projects/prompts", data_output_dir="/scratch/results")
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("DATA_INPUT_DIR", None)
-            os.environ.pop("DATA_OUTPUT_DIR", None)
-            self.assertEqual(cfg.get_path("DATA_INPUT_DIR"), Path("/projects/prompts"))
-            self.assertEqual(cfg.get_path("DATA_OUTPUT_DIR"), Path("/scratch/results"))
-
-
-class TestConfigGetPath(unittest.TestCase):
-    def setUp(self):
-        self.cfg = Config(data_dir="/tmp/data", logs_dir="/tmp/logs")
-
-    def test_code_path_highest_priority(self):
-        result = self.cfg.get_path("DATA_INPUT_DIR", code_path="/override/path")
-        self.assertEqual(result, Path("/override/path"))
-
-    def test_env_var_used_when_no_code_path(self):
-        with patch.dict(os.environ, {"DATA_INPUT_DIR": "/env/input"}):
-            result = self.cfg.get_path("DATA_INPUT_DIR")
-        self.assertEqual(result, Path("/env/input"))
-
-    def test_default_path_used_as_fallback(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("DATA_INPUT_DIR", None)
-            result = self.cfg.get_path("DATA_INPUT_DIR")
-        self.assertIn("input", str(result))
-
-    def test_unknown_path_falls_back_to_workspace(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("UNKNOWN_KEY", None)
-            result = self.cfg.get_path("UNKNOWN_KEY")
-        self.assertIn("unknown_key", str(result))
-
-
-class TestConfigGetSetting(unittest.TestCase):
-    def setUp(self):
-        self.cfg = Config()
-
-    def test_code_value_beats_all(self):
-        result = self.cfg.get_setting("SLURM_PARTITION", code_value="my-partition")
-        self.assertEqual(result, "my-partition")
-
-    def test_env_var_beats_default(self):
-        with patch.dict(os.environ, {"SLURM_PARTITION": "env-partition"}):
-            result = self.cfg.get_setting("SLURM_PARTITION")
-        self.assertEqual(result, "env-partition")
-
-    def test_default_returned_when_nothing_set(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SLURM_PARTITION", None)
-            result = self.cfg.get_setting("SLURM_PARTITION")
-        self.assertIsNotNone(result)
-
-    def test_none_returned_for_unknown_setting(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("TOTALLY_UNKNOWN", None)
-            result = self.cfg.get_setting("TOTALLY_UNKNOWN")
-        self.assertIsNone(result)
+    def test_legacy_unprefixed_env_vars_are_ignored(self):
+        # DATA_INPUT_DIR/DATA_OUTPUT_DIR are no longer read by any config code;
+        # only LLMFLUX_-prefixed vars and explicit params resolve directories
+        with patch.dict(os.environ, {
+            "DATA_INPUT_DIR": "/legacy/inputs",
+            "DATA_OUTPUT_DIR": "/legacy/outputs",
+        }):
+            os.environ.pop("LLMFLUX_DATA_INPUT_DIR", None)
+            os.environ.pop("LLMFLUX_DATA_OUTPUT_DIR", None)
+            cfg = Config(data_dir="/tmp/mydata")
+        self.assertEqual(cfg.data_input_dir, "/tmp/mydata/input")
+        self.assertEqual(cfg.data_output_dir, "/tmp/mydata/output")
 
 
 class TestGetSlurmConfigMemory(unittest.TestCase):

--- a/tests/core/test_config_manager.py
+++ b/tests/core/test_config_manager.py
@@ -32,6 +32,11 @@ class TestConfigManagerSingleton(unittest.TestCase):
         self.assertEqual(config.data_dir, "/tmp/mydata")
         self.assertEqual(config.logs_dir, "/tmp/mylogs")
 
+    def test_reset_config_with_workspace(self):
+        config = ConfigManager.reset_config(workspace="/tmp/myworkspace")
+        self.assertEqual(str(config.workspace), "/tmp/myworkspace")
+        self.assertEqual(config.data_dir, "/tmp/myworkspace/data")
+
 
 class TestGetParameter(unittest.TestCase):
     def test_code_value_highest_priority(self):
@@ -136,4 +141,19 @@ class TestUpdateConfig(unittest.TestCase):
     def test_update_refreshes_derived_paths(self):
         ConfigManager.get_config()
         updated = ConfigManager.update_config(data_dir="/tmp/newdata")
-        self.assertIn("input", str(updated.default_paths.get("DATA_INPUT_DIR", "")))
+        self.assertEqual(str(updated.default_paths["DATA_INPUT_DIR"]), "/tmp/newdata/input")
+        self.assertEqual(str(updated.default_paths["DATA_OUTPUT_DIR"]), "/tmp/newdata/output")
+
+    def test_update_with_separate_input_output_dirs(self):
+        ConfigManager.get_config()
+        updated = ConfigManager.update_config(
+            data_input_dir="/projects/prompts", data_output_dir="/scratch/results"
+        )
+        self.assertEqual(str(updated.default_paths["DATA_INPUT_DIR"]), "/projects/prompts")
+        self.assertEqual(str(updated.default_paths["DATA_OUTPUT_DIR"]), "/scratch/results")
+
+    def test_update_data_dir_rederives_input_output(self):
+        ConfigManager.reset_config(data_input_dir="/old/inputs")
+        updated = ConfigManager.update_config(data_dir="/tmp/newdata")
+        self.assertEqual(updated.data_input_dir, "/tmp/newdata/input")
+        self.assertEqual(updated.data_output_dir, "/tmp/newdata/output")

--- a/tests/core/test_config_manager.py
+++ b/tests/core/test_config_manager.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 import llmflux.core.config_manager as cm_module
 from llmflux.core.config_manager import ConfigManager
@@ -29,13 +30,14 @@ class TestConfigManagerSingleton(unittest.TestCase):
 
     def test_reset_config_with_custom_dirs(self):
         config = ConfigManager.reset_config(data_dir="/tmp/mydata", logs_dir="/tmp/mylogs")
-        self.assertEqual(config.data_dir, "/tmp/mydata")
-        self.assertEqual(config.logs_dir, "/tmp/mylogs")
+        self.assertEqual(config.data_dir, str(Path("/tmp/mydata").resolve()))
+        self.assertEqual(config.logs_dir, str(Path("/tmp/mylogs").resolve()))
 
     def test_reset_config_with_workspace(self):
         config = ConfigManager.reset_config(workspace="/tmp/myworkspace")
-        self.assertEqual(str(config.workspace), "/tmp/myworkspace")
-        self.assertEqual(config.data_dir, "/tmp/myworkspace/data")
+        workspace = str(Path("/tmp/myworkspace").resolve())
+        self.assertEqual(str(config.workspace), workspace)
+        self.assertEqual(config.data_dir, f"{workspace}/data")
 
 
 class TestGetParameter(unittest.TestCase):
@@ -120,12 +122,12 @@ class TestUpdateConfig(unittest.TestCase):
     def test_update_data_dir(self):
         ConfigManager.get_config()
         updated = ConfigManager.update_config(data_dir="/tmp/updated_data")
-        self.assertEqual(updated.data_dir, "/tmp/updated_data")
+        self.assertEqual(updated.data_dir, str(Path("/tmp/updated_data").resolve()))
 
     def test_update_logs_dir(self):
         ConfigManager.get_config()
         updated = ConfigManager.update_config(logs_dir="/tmp/updated_logs")
-        self.assertEqual(updated.logs_dir, "/tmp/updated_logs")
+        self.assertEqual(updated.logs_dir, str(Path("/tmp/updated_logs").resolve()))
 
     def test_update_returns_same_singleton(self):
         original = ConfigManager.get_config()
@@ -147,7 +149,8 @@ class TestUpdateConfig(unittest.TestCase):
         self.assertEqual(updated.data_output_dir, "/scratch/results")
 
     def test_update_data_dir_rederives_input_output(self):
-        ConfigManager.reset_config(data_input_dir="/old/inputs")
+        ConfigManager.reset_config(data_input_dir="/tmp/old/inputs")
         updated = ConfigManager.update_config(data_dir="/tmp/newdata")
-        self.assertEqual(updated.data_input_dir, "/tmp/newdata/input")
-        self.assertEqual(updated.data_output_dir, "/tmp/newdata/output")
+        data_dir = str(Path("/tmp/newdata").resolve())
+        self.assertEqual(updated.data_input_dir, f"{data_dir}/input")
+        self.assertEqual(updated.data_output_dir, f"{data_dir}/output")

--- a/tests/core/test_config_manager.py
+++ b/tests/core/test_config_manager.py
@@ -138,19 +138,13 @@ class TestUpdateConfig(unittest.TestCase):
         ConfigManager.update_config()
         self.assertEqual(ConfigManager.get_config().data_dir, original_data_dir)
 
-    def test_update_refreshes_derived_paths(self):
-        ConfigManager.get_config()
-        updated = ConfigManager.update_config(data_dir="/tmp/newdata")
-        self.assertEqual(str(updated.default_paths["DATA_INPUT_DIR"]), "/tmp/newdata/input")
-        self.assertEqual(str(updated.default_paths["DATA_OUTPUT_DIR"]), "/tmp/newdata/output")
-
     def test_update_with_separate_input_output_dirs(self):
         ConfigManager.get_config()
         updated = ConfigManager.update_config(
             data_input_dir="/projects/prompts", data_output_dir="/scratch/results"
         )
-        self.assertEqual(str(updated.default_paths["DATA_INPUT_DIR"]), "/projects/prompts")
-        self.assertEqual(str(updated.default_paths["DATA_OUTPUT_DIR"]), "/scratch/results")
+        self.assertEqual(updated.data_input_dir, "/projects/prompts")
+        self.assertEqual(updated.data_output_dir, "/scratch/results")
 
     def test_update_data_dir_rederives_input_output(self):
         ConfigManager.reset_config(data_input_dir="/old/inputs")

--- a/tests/slurm/test_runner.py
+++ b/tests/slurm/test_runner.py
@@ -116,9 +116,9 @@ class TestSlurmRunner(unittest.TestCase):
         runner = SlurmRunner()
         env_vars = runner._setup_environment("test_workspace")
 
-        self.assertEqual(env_vars["MODELS_DIR"], str(self.models_dir))
-        self.assertEqual(env_vars["LOGS_DIR"], str(self.logs_dir))
-        self.assertEqual(env_vars["CONTAINERS_DIR"], str(self.containers_dir))
+        self.assertEqual(env_vars["MODELS_DIR"], str(self.models_dir.resolve()))
+        self.assertEqual(env_vars["LOGS_DIR"], str(self.logs_dir.resolve()))
+        self.assertEqual(env_vars["CONTAINERS_DIR"], str(self.containers_dir.resolve()))
         self.assertEqual(env_vars["PROJECT_ROOT"], "test_workspace")
 
     @patch("llmflux.slurm.runner.ConfigManager")

--- a/tests/slurm/test_runner.py
+++ b/tests/slurm/test_runner.py
@@ -414,6 +414,58 @@ class TestSlurmRunner(unittest.TestCase):
         # Verify the job was submitted, confirming the input file was resolved
         mock_run.assert_called_once()
 
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_input_resolution_and_bind_mount_share_data_input_dir(
+        self,
+        mock_run,
+        mock_load_model_config,
+        mock_registry,
+        mock_config_manager,
+    ):
+        """A data_input_dir override must resolve input files and set up the
+        Apptainer bind mount from the same directory, not two different ones."""
+        custom_input_dir = self.test_dir / "custom_inputs"
+        custom_input_dir.mkdir()
+        custom_jsonl = custom_input_dir / "external.jsonl"
+        custom_jsonl.write_text(self.jsonl_path.read_text())
+
+        config = Config(
+            data_dir=str(self.data_dir),
+            data_input_dir=str(custom_input_dir),
+            models_dir=str(self.models_dir),
+            logs_dir=str(self.logs_dir),
+            containers_dir=str(self.containers_dir),
+            slurm=self.slurm_config,
+            models=[self.model_config],
+        )
+        mock_config_manager.return_value.get_config.return_value = config
+        mock_config_manager.return_value.get_parameter.return_value = "4"
+        mock_load_model_config.return_value = self.model_config
+
+        mock_run.return_value.stdout = "Submitted batch job 12345"
+
+        runner = SlurmRunner()
+        # runner.data_input_dir is what run() uses to resolve a bare filename
+        # (runner.py's "relative to the data input directory" fallback).
+        self.assertEqual(runner.data_input_dir, custom_input_dir.resolve())
+
+        # Only exists under the overridden data_input_dir, not {data_dir}/input.
+        runner.run(
+            input_path="external.jsonl",
+            output_path=str(self.output_path),
+            model="test:7b",
+        )
+
+        mock_run.assert_called_once()
+        submitted_env = mock_run.call_args.kwargs["env"]
+        # The Apptainer bind mount must be built from that same directory
+        # runner.data_input_dir resolved input against, not a separately
+        # computed default.
+        self.assertEqual(submitted_env["DATA_INPUT_DIR"], str(runner.data_input_dir))
+
 
 class TestSlurmRunnerServe(unittest.TestCase):
     """Tests for SlurmRunner.serve()."""

--- a/tests/slurm/test_runner.py
+++ b/tests/slurm/test_runner.py
@@ -466,6 +466,79 @@ class TestSlurmRunner(unittest.TestCase):
         # computed default.
         self.assertEqual(submitted_env["DATA_INPUT_DIR"], str(runner.data_input_dir))
 
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_input_already_in_data_input_dir_not_rewritten(
+        self,
+        mock_run,
+        mock_load_model_config,
+        mock_registry,
+        mock_config_manager,
+    ):
+        """An input file already inside data_input_dir must be used in place,
+        not copied onto itself."""
+        config = Config(
+            data_dir=str(self.data_dir),
+            data_input_dir=str(self.data_dir),
+            models_dir=str(self.models_dir),
+            logs_dir=str(self.logs_dir),
+            containers_dir=str(self.containers_dir),
+            slurm=self.slurm_config,
+            models=[self.model_config],
+        )
+        mock_config_manager.return_value.get_config.return_value = config
+        mock_config_manager.return_value.get_parameter.return_value = "4"
+        mock_load_model_config.return_value = self.model_config
+
+        mock_run.return_value.stdout = "Submitted batch job 12345"
+
+        mtime_before = self.jsonl_path.stat().st_mtime_ns
+
+        runner = SlurmRunner()
+        runner.run(
+            input_path=str(self.jsonl_path),
+            output_path=str(self.output_path),
+            model="test:7b",
+        )
+
+        mock_run.assert_called_once()
+        self.assertEqual(self.jsonl_path.stat().st_mtime_ns, mtime_before)
+
+    @patch("llmflux.slurm.runner.ConfigManager")
+    @patch("llmflux.slurm.runner.JobRegistry")
+    @patch("llmflux.core.config.Config.load_model_config")
+    @patch("llmflux.slurm.runner.subprocess.run")
+    def test_directory_input_raises_and_is_preserved(
+        self,
+        mock_run,
+        mock_load_model_config,
+        mock_registry,
+        mock_config_manager,
+    ):
+        """A directory passed as input must raise instead of being staged —
+        the old copytree path could rmtree the original directory."""
+        mock_config_manager.return_value.get_config.return_value = self.config
+        mock_config_manager.return_value.get_parameter.return_value = "4"
+        mock_load_model_config.return_value = self.model_config
+
+        prompts_dir = self.test_dir / "prompts"
+        prompts_dir.mkdir()
+        prompts_file = prompts_dir / "prompts.jsonl"
+        prompts_file.write_text(self.jsonl_path.read_text())
+
+        runner = SlurmRunner()
+        with self.assertRaises(ValueError):
+            runner.run(
+                input_path=str(prompts_dir),
+                output_path=str(self.output_path),
+                model="test:7b",
+            )
+
+        mock_run.assert_not_called()
+        self.assertTrue(prompts_file.exists())
+
 
 class TestSlurmRunnerServe(unittest.TestCase):
     """Tests for SlurmRunner.serve()."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -618,7 +618,6 @@ class TestRunnerEnvironmentVariables:
         # Setup config manager mock
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",
@@ -737,7 +736,6 @@ class TestRunnerEnvironmentVariables:
         # Setup mocks (same as above)
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",
@@ -799,7 +797,6 @@ class TestRunnerEnvironmentVariables:
         # Setup mocks
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",
@@ -872,7 +869,6 @@ class TestEnvironmentVariablePrefixes:
         # Setup mocks
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",
@@ -994,7 +990,6 @@ class TestEnvironmentVariablePrefixes:
         # Setup mocks (same as above)
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",
@@ -1107,7 +1102,6 @@ class TestEnvironmentVariablePrefixes:
         # Setup mocks
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",
@@ -1206,7 +1200,6 @@ class TestEnvironmentVariablePrefixes:
         # Setup mocks
         mock_manager = MagicMock()
         mock_config = MagicMock()
-        mock_config.get_path.return_value = temp_dir
         mock_config.ensure_directory = MagicMock()
         mock_config.get_slurm_config.return_value = MagicMock(
             account="test-account",


### PR DESCRIPTION
workspace, data dir are configurable from the env

1. Bug fix — update_config derived paths
- src/llmflux/core/config_manager.py: update_config() previously rebuilt DATA_INPUT_DIR, DATA_OUTPUT_DIR, MODELS_DIR, LOGS_DIR, and CONTAINERS_DIR from hardcoded config.workspace / ... paths, silently ignoring any data_dir/models_dir/etc. overrides passed in the same call. It now derives them from the configured directory attributes.

2. Configurable workspace
- src/llmflux/core/config.py: Config.__init__ accepts a workspace parameter, resolved as workspace arg → LLMFLUX_WORKSPACE env var → Path.cwd(). All workspace-derived paths (data/models/logs/containers defaults, .ollama/.vllm engine homes, Apptainer tmp/cache dirs, get_path fallback) follow it automatically.
- src/llmflux/core/config_manager.py: reset_config() accepts and forwards workspace (deliberately not added to update_config, since changing workspace on a live config would leave derived values stale).

3. Configurable input/output directories (independent of data_dir)
- src/llmflux/core/config.py: Config gained data_input_dir and data_output_dir attributes, resolved as param → LLMFLUX_DATA_INPUT_DIR / LLMFLUX_DATA_OUTPUT_DIR env vars → {data_dir}/input|output. default_paths now points at these instead of hardcoding {data_dir}/input|output.
- src/llmflux/core/config_manager.py: reset_config() and update_config() accept both; update_config(data_dir=...) re-derives input/output so they follow the new data_dir unless explicitly overridden in the same call.
- No runner changes needed — SlurmRunner's pre-existing hasattr(config, 'data_input_dir') guards now find the real attributes, so get_path(), the runner's directories, the SLURM job environment, and the Apptainer bind mounts all agree (fixing the split-brain where env overrides affected path resolution but not bind mounts).
- Removed unused `config.get_envrionment()` method, `get_defaults` , `get_setting` . Removed test cases for these methods

4. Updated pyproject version as this is a breaking change - no backwards compatability
