### PR TITLE
flashinfer cache in hostvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- vLLM jobs no longer fail to start with `OSError: [Errno 30] Read-only file
+  system: '{workspace}/.cache/flashinfer'`. `XDG_CACHE_HOME` and
+  `FLASHINFER_WORKSPACE_BASE` were only exported with the `APPTAINERENV_`
+  prefix, so the generated batch script expanded them to empty strings in its
+  `mkdir -p` and `--bind` lines: the workspace cache directory was never
+  created on the host and never bound into the container, leaving it read-only
+  where FlashInfer writes its JIT kernel cache. Both are now host variables as
+  well.
+- `update_config()` no longer discards the directory overrides passed to it.
+  After applying its arguments it rebuilt `DATA_INPUT_DIR`, `DATA_OUTPUT_DIR`,
+  `MODELS_DIR`, `LOGS_DIR` and `CONTAINERS_DIR` from hardcoded
+  `config.workspace / ...` paths, so a `data_dir` or `models_dir` passed in the
+  same call was silently ignored by everything reading the derived paths. They
+  are now derived from the configured directory attributes
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
+- Directory overrides now reach the Apptainer bind mounts. Path resolution and
+  the bind mounts were computed from two different sources, so an override
+  could change where the runner looked for input while the container was still
+  bound to the default location
+  (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 - `--mem` CLI flag and programmatic memory settings now actually reach the
   generated `#SBATCH --mem` line. Previously `SlurmConfig` had two fields for
   the same setting (`mem` and `memory`); the CLI and examples set `mem`, but

--- a/src/llmflux/slurm/runner.py
+++ b/src/llmflux/slurm/runner.py
@@ -112,6 +112,12 @@ class SlurmRunner:
         # Resolve HuggingFace cache directory with a default under workspace.
         hf_home = os.getenv('HF_HOME') or str(workspace_path / ".cache" / "huggingface")
 
+        # Cache locations for engine-side JIT artifacts (e.g. FlashInfer kernels).
+        # These must also be host vars: the batch script uses them for mkdir and
+        # --bind, and an unbound cache dir is read-only inside the container.
+        xdg_cache_home = str(workspace_path / ".cache")
+        flashinfer_workspace_base = str(workspace_path)
+
         # HOST-ONLY variables (used by bash script, NOT passed to container)
         host_vars = {
             'DATA_INPUT_DIR': str(self.data_input_dir),
@@ -129,6 +135,8 @@ class SlurmRunner:
             'VLLM_HOME': str(self.workspace / ".vllm"),
             'VLLM_MODELS': str(self.workspace / ".vllm" / "models"),
             'HF_HOME': hf_home,  # Used for mkdir and --bind
+            'XDG_CACHE_HOME': xdg_cache_home,  # Used for mkdir and --bind
+            'FLASHINFER_WORKSPACE_BASE': flashinfer_workspace_base,  # Used for mkdir and --bind
             'PROJECT_ROOT': str(workspace_path),  # Used in bash script for Python path
         }
 
@@ -146,8 +154,8 @@ class SlurmRunner:
             'APPTAINERENV_OLLAMA_SCHED_SPREAD': ollama_sched_spread,
             'APPTAINERENV_VLLM_SCHED_SPREAD': vllm_sched_spread,
             'APPTAINERENV_HF_HOME': hf_home,
-            'APPTAINERENV_XDG_CACHE_HOME': str(workspace_path / ".cache"),
-            'APPTAINERENV_FLASHINFER_WORKSPACE_BASE': str(workspace_path),
+            'APPTAINERENV_XDG_CACHE_HOME': xdg_cache_home,
+            'APPTAINERENV_FLASHINFER_WORKSPACE_BASE': flashinfer_workspace_base,
             # Use system CA bundle for HTTPS (e.g. HuggingFace model downloads).
             # Empty values break downloads with "No CA certificates were loaded".
             'APPTAINERENV_CURL_CA_BUNDLE': '/etc/ssl/certs/ca-certificates.crt',

--- a/tests/slurm/test_runner.py
+++ b/tests/slurm/test_runner.py
@@ -122,6 +122,28 @@ class TestSlurmRunner(unittest.TestCase):
         self.assertEqual(env_vars["PROJECT_ROOT"], "test_workspace")
 
     @patch("llmflux.slurm.runner.ConfigManager")
+    def test_setup_environment_exports_cache_vars_to_host(self, mock_config_manager):
+        """Cache dirs used by the batch script's mkdir/--bind must be host vars.
+
+        If they are only set as APPTAINERENV_*, the workspace cache dir is never
+        created or bound and FlashInfer fails with a read-only filesystem error.
+        """
+        mock_config_manager.return_value.get_config.return_value = self.config
+
+        runner = SlurmRunner()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("XDG_CACHE_HOME", None)
+            env_vars = runner._setup_environment("test_workspace")
+
+        self.assertEqual(env_vars["XDG_CACHE_HOME"], str(Path("test_workspace") / ".cache"))
+        self.assertEqual(env_vars["FLASHINFER_WORKSPACE_BASE"], "test_workspace")
+        self.assertEqual(env_vars["APPTAINERENV_XDG_CACHE_HOME"], env_vars["XDG_CACHE_HOME"])
+        self.assertEqual(
+            env_vars["APPTAINERENV_FLASHINFER_WORKSPACE_BASE"],
+            env_vars["FLASHINFER_WORKSPACE_BASE"],
+        )
+
+    @patch("llmflux.slurm.runner.ConfigManager")
     def test_setup_environment_prefers_huggingface_token(self, mock_config_manager):
         """HUGGINGFACE_TOKEN wins when both token env vars are set."""
         mock_config_manager.return_value.get_config.return_value = self.config


### PR DESCRIPTION
XGDCache and flashinfer cache is in host vars so that it is not read-only in the apptainer.
