### PR TITLE
fix: find images in a directory in vision_to_jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `vision_to_jsonl()` now finds images in a directory. Its default
+  `file_pattern` was `"*.{jpg,jpeg,png,gif,webp,bmp}"`, but Python's `glob` has
+  no brace expansion, so the pattern matched nothing and a directory of images
+  produced an empty JSONL file with only an `INFO - Found 0 images` line.
+  Directory discovery now defaults to every supported extension, matched
+  case-insensitively so `IMG_1234.JPG` is included; an explicit `file_pattern`
+  is still honored (brace groups are expanded, so callers that passed the old
+  default keep working) and `"**/*.jpg"` still recurses. An empty result now
+  logs a warning instead of an info line
+  (see [#131](https://github.com/Center-for-AI-Innovation/LLMFlux/issues/131)).
+
 - `--mem` CLI flag and programmatic memory settings now actually reach the
   generated `#SBATCH --mem` line. Previously `SlurmConfig` had two fields for
   the same setting (`mem` and `memory`); the CLI and examples set `mem`, but

--- a/src/llmflux/converters/vision.py
+++ b/src/llmflux/converters/vision.py
@@ -13,6 +13,54 @@ from .utils import create_jsonl_entry, generate_custom_id
 
 logger = logging.getLogger(__name__)
 
+# Extensions vLLM/Ollama vision models accept, mapped to the MIME type used in
+# the data: URL. Also drives directory discovery when no file_pattern is given.
+IMAGE_MIME_TYPES = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.bmp': 'image/bmp',
+}
+
+
+def _expand_braces(pattern: str) -> List[str]:
+    """Expand one {a,b,c} group into separate patterns.
+
+    glob has no brace expansion, so "*.{jpg,png}" silently matches nothing.
+    Callers that pass such a pattern (it used to be this function's default)
+    get the extensions they meant.
+    """
+    start = pattern.find('{')
+    end = pattern.find('}', start + 1)
+    if start == -1 or end == -1:
+        return [pattern]
+    prefix, options, suffix = pattern[:start], pattern[start + 1:end], pattern[end + 1:]
+    return [f"{prefix}{option}{suffix}" for option in options.split(',')]
+
+
+def _find_images(directory: str, file_pattern: Optional[str]) -> List[str]:
+    """List image files in a directory.
+
+    With no file_pattern, every supported extension is matched case-insensitively
+    so phone/camera names like IMG_1234.JPG are included. An explicit pattern is
+    passed to glob (brace groups expanded), keeping "**/*.jpg" style recursion.
+    """
+    if file_pattern is None:
+        return sorted(
+            os.path.join(directory, name)
+            for name in os.listdir(directory)
+            if os.path.splitext(name)[1].lower() in IMAGE_MIME_TYPES
+            and os.path.isfile(os.path.join(directory, name))
+        )
+
+    matches = set()
+    for expanded in _expand_braces(file_pattern):
+        matches.update(glob.glob(os.path.join(directory, expanded), recursive=True))
+    return sorted(matches)
+
+
 def encode_image(image_path: str) -> str:
     """Base64 encode an image file.
     
@@ -43,15 +91,7 @@ def get_image_mime_type(image_path: str) -> str:
         MIME type string
     """
     ext = os.path.splitext(image_path)[1].lower()
-    mime_types = {
-        '.png': 'image/png',
-        '.jpg': 'image/jpeg',
-        '.jpeg': 'image/jpeg',
-        '.gif': 'image/gif',
-        '.webp': 'image/webp',
-        '.bmp': 'image/bmp'
-    }
-    return mime_types.get(ext, 'application/octet-stream')
+    return IMAGE_MIME_TYPES.get(ext, 'application/octet-stream')
 
 def vision_to_jsonl(
     input_path: str,
@@ -61,7 +101,7 @@ def vision_to_jsonl(
     system_prompt: Optional[str] = None,
     model: Optional[str] = None,
     max_image_size: int = 10 * 1024 * 1024,
-    file_pattern: str = "*.{jpg,jpeg,png,gif,webp,bmp}"
+    file_pattern: Optional[str] = None
 ) -> str:
     """Convert images to JSONL format.
     
@@ -73,7 +113,9 @@ def vision_to_jsonl(
         system_prompt: Optional system prompt
         model: Vision-capable model to use
         max_image_size: Maximum image file size in bytes
-        file_pattern: Glob pattern for image files
+        file_pattern: Optional glob pattern for image files. Defaults to every
+            supported extension, matched case-insensitively and non-recursively.
+            Pass e.g. "**/*.jpg" to recurse into subdirectories.
         
     Returns:
         Path to generated JSONL file
@@ -101,9 +143,16 @@ def vision_to_jsonl(
         image_paths = []
         if os.path.isdir(input_path):
             # Handle directory of images
-            pattern = os.path.join(input_path, file_pattern)
-            image_paths = glob.glob(pattern, recursive=True)
-            logger.info(f"Found {len(image_paths)} images in {input_path}")
+            image_paths = _find_images(input_path, file_pattern)
+            if image_paths:
+                logger.info(f"Found {len(image_paths)} images in {input_path}")
+            else:
+                # Loud, because the result is a valid-but-empty JSONL file.
+                logger.warning(
+                    f"No images found in {input_path}"
+                    + (f" matching pattern '{file_pattern}'" if file_pattern else "")
+                    + f". Supported extensions: {', '.join(sorted(IMAGE_MIME_TYPES))}"
+                )
         else:
             # Handle single image
             image_paths = [input_path]

--- a/tests/converters/test_vision.py
+++ b/tests/converters/test_vision.py
@@ -151,6 +151,90 @@ class TestVisionToJsonl(unittest.TestCase):
             lines = [l for l in f if l.strip()]
         self.assertEqual(len(lines), 3)
 
+    def test_directory_default_pattern_finds_all_supported_extensions(self):
+        """The default must actually match images — it used to be a brace glob,
+        which Python's glob does not expand, so directories yielded nothing."""
+        img_dir = self.test_dir / "images"
+        img_dir.mkdir()
+        for name in ("a.png", "b.jpg", "c.jpeg", "d.gif", "e.webp", "f.bmp"):
+            _write_tiny_png(str(img_dir / name))
+        (img_dir / "notes.txt").write_text("not an image")
+        out = str(self.test_dir / "out.jsonl")
+
+        vision_to_jsonl(str(img_dir), output_path=out)
+
+        with open(out) as f:
+            lines = [l for l in f if l.strip()]
+        self.assertEqual(len(lines), 6)
+
+    def test_directory_default_pattern_is_case_insensitive(self):
+        """Phones and cameras produce IMG_1234.JPG."""
+        img_dir = self.test_dir / "images"
+        img_dir.mkdir()
+        for name in ("IMG_1.JPG", "IMG_2.PNG"):
+            _write_tiny_png(str(img_dir / name))
+        out = str(self.test_dir / "out.jsonl")
+
+        vision_to_jsonl(str(img_dir), output_path=out)
+
+        with open(out) as f:
+            lines = [l for l in f if l.strip()]
+        self.assertEqual(len(lines), 2)
+
+    def test_directory_default_pattern_is_not_recursive(self):
+        img_dir = self.test_dir / "images"
+        (img_dir / "nested").mkdir(parents=True)
+        _write_tiny_png(str(img_dir / "top.png"))
+        _write_tiny_png(str(img_dir / "nested" / "deep.png"))
+        out = str(self.test_dir / "out.jsonl")
+
+        vision_to_jsonl(str(img_dir), output_path=out)
+
+        with open(out) as f:
+            lines = [l for l in f if l.strip()]
+        self.assertEqual(len(lines), 1)
+
+    def test_recursive_pattern_descends_into_subdirectories(self):
+        img_dir = self.test_dir / "images"
+        (img_dir / "nested").mkdir(parents=True)
+        _write_tiny_png(str(img_dir / "top.png"))
+        _write_tiny_png(str(img_dir / "nested" / "deep.png"))
+        out = str(self.test_dir / "out.jsonl")
+
+        vision_to_jsonl(str(img_dir), output_path=out, file_pattern="**/*.png")
+
+        with open(out) as f:
+            lines = [l for l in f if l.strip()]
+        self.assertEqual(len(lines), 2)
+
+    def test_legacy_brace_pattern_is_expanded(self):
+        """The old broken default should still work if a caller passes it."""
+        img_dir = self.test_dir / "images"
+        img_dir.mkdir()
+        for name in ("a.png", "b.jpg"):
+            _write_tiny_png(str(img_dir / name))
+        out = str(self.test_dir / "out.jsonl")
+
+        vision_to_jsonl(
+            str(img_dir), output_path=out, file_pattern="*.{jpg,jpeg,png,gif,webp,bmp}"
+        )
+
+        with open(out) as f:
+            lines = [l for l in f if l.strip()]
+        self.assertEqual(len(lines), 2)
+
+    def test_empty_directory_warns(self):
+        """An empty result is silent otherwise: a valid but empty JSONL file."""
+        img_dir = self.test_dir / "images"
+        img_dir.mkdir()
+        (img_dir / "notes.txt").write_text("not an image")
+        out = str(self.test_dir / "out.jsonl")
+
+        with self.assertLogs("llmflux.converters.vision", level="WARNING") as logs:
+            vision_to_jsonl(str(img_dir), output_path=out)
+
+        self.assertIn("No images found", "\n".join(logs.output))
+
     def test_oversized_image_skipped(self):
         img = self._make_image()
         out = str(self.test_dir / "out.jsonl")


### PR DESCRIPTION
Closes #131

## What was wrong

`vision_to_jsonl()` defaulted `file_pattern` to `"*.{jpg,jpeg,png,gif,webp,bmp}"` and passed it straight to `glob.glob()`. Python's `glob` has no brace expansion, so the pattern matched nothing: pointing the converter at a directory of images produced an empty JSONL file with no error, only `INFO - Found 0 images`.

Single-file input and explicit patterns were unaffected, and the existing directory test passed `file_pattern="*.png"` (`tests/converters/test_vision.py:149`), which is why the suite never caught it.

## Fix

- Directory discovery defaults to every supported extension, matched **case-insensitively** so `IMG_1234.JPG` — what phones and cameras produce — is included.
- An explicit `file_pattern` is still globbed. Brace groups are expanded first, so callers that passed the old default (copied from the signature or docs) now get the extensions they meant, and `"**/*.jpg"` still recurses.
- An empty result logs a **warning** naming the supported extensions, rather than an info line. The failure is otherwise silent: a valid, empty JSONL.
- Extracted the MIME map to a module-level `IMAGE_MIME_TYPES` so discovery and `get_image_mime_type()` share one source of truth.

Measured on a directory containing `a.jpg`, `b.png`, `c.jpeg`, `E.JPG` and `nested/d.jpg`:

| call | before | after |
| --- | --- | --- |
| directory, defaults | **0** | **4** (non-recursive, `.JPG` included) |
| `file_pattern="*.jpg"` | 1 | 1 |
| legacy brace pattern | **0** | 3 |
| `file_pattern="**/*.jpg"` | 2 | 2 |
| single image file | 1 | 1 |

## Testing

6 new tests: default extensions, case-insensitivity, non-recursive default, recursive pattern, legacy brace pattern, empty-directory warning. Full suite: 429 passed.

## Compatibility

No breaking change. Explicit patterns behave as before; only the default changed, and only from "matches nothing" to "matches images".

## Note

Independent of #130 — both branch from `main` and touch different files, so they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
