### PR TITLE
docs: remove duplicated changelog entry, restore lost PR reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mkdir -p` and `--bind` lines: the workspace cache directory was never
   created on the host and never bound into the container, leaving it read-only
   where FlashInfer writes its JIT kernel cache. Both are now host variables as
-  well.
+  well
+  (see [#125](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/125)).
 - `update_config()` no longer discards the directory overrides passed to it.
   After applying its arguments it rebuilt `DATA_INPUT_DIR`, `DATA_OUTPUT_DIR`,
   `MODELS_DIR`, `LOGS_DIR` and `CONTAINERS_DIR` from hardcoded
@@ -57,10 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same call was silently ignored by everything reading the derived paths. They
   are now derived from the configured directory attributes
   (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
-- Directory overrides now reach the Apptainer bind mounts. Path resolution and
-  the bind mounts were computed from two different sources, so an override
-  could change where the runner looked for input while the container was still
-  bound to the default location
 - `SlurmRunner.run()` resolved the input-file fallback and default output path
   via `Config.get_path()`, while the Apptainer bind mounts used
   `self.data_input_dir` / `self.data_output_dir` — two different reads of the


### PR DESCRIPTION
Documentation only — no code or behavior change.

## What

The #125 merge left two entries under `Unreleased/Fixed` describing the same fix:

- "Directory overrides now reach the Apptainer bind mounts. Path resolution and the bind mounts were computed from two different sources…"
- "`SlurmRunner.run()` resolved the input-file fallback and default output path via `Config.get_path()`, while the Apptainer bind mounts used `self.data_input_dir`…" (from #121)

The first also lost its trailing `(see #121)` in the merge, so it read as an unattributed fragment ending mid-thought.

## Changes

- Dropped the vaguer duplicate; kept the precise #121 entry.
- Added the missing `(see #125)` reference to the FlashInfer entry, which was the only other bullet in `Unreleased` without one.

All 12 entries under `Unreleased` now carry a PR or issue reference, matching the file's convention.

Noted during the review of #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
