### PR TITLE
Pin the generated batch stage to the submitting interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (see [#121](https://github.com/Center-for-AI-Innovation/LLMFlux/pull/121)).
 
 ### Fixed
+- The generated batch stage now runs under the interpreter that generated it
+  (`sys.executable`) instead of resolving a bare `python3` from whatever `PATH`
+  the compute node inherits. The `llmflux` CLI has an absolute shebang and is
+  therefore immune to `PATH` shadowing, so any other interpreter ahead on `PATH`
+  — an activated venv, a second conda env, a notebook kernel — left the CLI
+  working while the batch stage silently picked up a Python without `llmflux`.
+  The job then failed with `ModuleNotFoundError: No module named 'llmflux'` only
+  *after* the model had loaded and the server had passed its health check, so it
+  read as a mid-run crash rather than an environment problem. Affects both the
+  vLLM and Ollama batch paths
+  (see [#142](https://github.com/Center-for-AI-Innovation/LLMFlux/issues/142)).
+- The generated script now exits with the batch stage's status. Cleanup always
+  succeeds and the script's last statement was `kill -9 … || true`, so a failed
+  batch stage exited 0 and Slurm recorded the job COMPLETED with no output.
+- Dropped `sys.path.append('$PROJECT_ROOT')` from the generated batch stage.
+  `PROJECT_ROOT` is the user's working directory, and under the `src/` layout it
+  can never contain the `llmflux` package, so the line was dead code that
+  disguised the missing interpreter pin above.
 
 - `vision_to_jsonl()` now finds images in a directory. Its default
   `file_pattern` was `"*.{jpg,jpeg,png,gif,webp,bmp}"`, but Python's `glob` has

--- a/src/llmflux/slurm/engine/ollama.py
+++ b/src/llmflux/slurm/engine/ollama.py
@@ -1,4 +1,5 @@
 import shlex
+import sys
 from pathlib import Path
 
 # This function generates an ollama batch script for running llmflux
@@ -190,10 +191,8 @@ def create_ollama_batch_script(
             "wait $OLLAMA_PID",
         ] if mode == "serve" else [
             "# Run processor",
-            f"python3 -c \"",
-            "import sys",
+            f"{shlex.quote(sys.executable)} -c \"",
             "import os",
-            "sys.path.append('$PROJECT_ROOT')",
             "from llmflux.core.config import Config",
             "from llmflux.processors import BatchProcessor",
             "",
@@ -234,6 +233,7 @@ def create_ollama_batch_script(
             "",
             f"batch_processor.run('{input_file}', '{output_file}', 'ollama', **run_kwargs)",
             "\"",
+            "BATCH_RC=$?",
         ]),
         "",
         "# Cleanup",
@@ -246,6 +246,7 @@ def create_ollama_batch_script(
         "fi",
         "if [ -d \"$APPTAINER_CACHEDIR\" ] && [ -w \"$APPTAINER_CACHEDIR\" ]; then",
         "    rm -rf \"$APPTAINER_CACHEDIR\"",
-        "fi"
+        "fi",
+        "exit ${BATCH_RC:-0}"
     ])
     return job_script

--- a/src/llmflux/slurm/engine/vllm.py
+++ b/src/llmflux/slurm/engine/vllm.py
@@ -1,4 +1,5 @@
 import shlex
+import sys
 from pathlib import Path
 
 def create_vllm_batch_script(
@@ -189,10 +190,8 @@ def create_vllm_batch_script(
             "wait $VLLM_PID",
         ] if mode == "serve" else [
             "# Run processor",
-            "python3 -c \"",
-            "import sys",
+            f"{shlex.quote(sys.executable)} -c \"",
             "import os",
-            "sys.path.append('$PROJECT_ROOT')",
             "from llmflux.core.config import Config",
             "from llmflux.processors import BatchProcessor",
             "",
@@ -235,6 +234,7 @@ def create_vllm_batch_script(
             "",
             f"batch_processor.run('{input_file}', '{output_file}', 'vllm', **run_kwargs)",
             "\"",
+            "BATCH_RC=$?",
         ]),
         "",
         "# Cleanup",
@@ -252,6 +252,6 @@ def create_vllm_batch_script(
         "kill $VLLM_PID 2>/dev/null || true",
         "sleep 2",
         "kill -9 $VLLM_PID 2>/dev/null || true",
-        ""
+        "exit ${BATCH_RC:-0}"
     ])
     return job_script

--- a/tests/slurm/test_engine_scripts.py
+++ b/tests/slurm/test_engine_scripts.py
@@ -1,5 +1,9 @@
 """Tests for SLURM batch script generation (vllm and ollama engines)."""
 
+import shlex
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -149,6 +153,72 @@ class TestCreateOllamaBatchScript(unittest.TestCase):
     def test_ollama_serve_present(self):
         full = "\n".join(self._call())
         self.assertIn("ollama serve", full)
+
+
+
+class TestBatchStageInterpreter(unittest.TestCase):
+    """The batch stage must name a specific interpreter (LLMFlux#142).
+
+    The `llmflux` console script has an absolute shebang and is immune to PATH
+    shadowing. The batch stage used to resolve a bare `python3`, so any other
+    interpreter ahead on PATH left the CLI working while the batch stage picked
+    up a Python without llmflux — failing only after the server was already up.
+    """
+
+    def _scripts(self):
+        from llmflux.slurm.engine.vllm import create_vllm_batch_script
+        from llmflux.slurm.engine.ollama import create_ollama_batch_script
+
+        common = dict(
+            account="a", partition="p", nodes="1", gpus_per_node="1",
+            time="01:00:00", memory="8G", cpus_per_task="2",
+            logs_dir=Path("/logs"), input_file=Path("/in.jsonl"),
+            output_file=Path("/out.json"), job_name="j",
+            slurm_config=_make_slurm_config(None),
+        )
+        for name, fn in (("vllm", create_vllm_batch_script),
+                         ("ollama", create_ollama_batch_script)):
+            for mode in ("batch", "serve"):
+                yield name, mode, fn(mode=mode, email="a@b.c", **common)
+
+    def test_batch_stage_names_the_submitting_interpreter(self):
+        for name, mode, script in self._scripts():
+            if mode == "serve":
+                continue
+            with self.subTest(engine=name):
+                self.assertIn(f"{shlex.quote(sys.executable)} -c \"", script)
+                self.assertNotIn("python3 -c \"", script)
+
+    def test_batch_stage_has_no_project_root_syspath_hack(self):
+        """PROJECT_ROOT is the user's cwd; under the src/ layout it can never
+        contain the llmflux package."""
+        for name, mode, script in self._scripts():
+            with self.subTest(engine=name, mode=mode):
+                self.assertFalse(any(
+                    "sys.path.append('$PROJECT_ROOT')" in l for l in script))
+
+    def test_batch_exit_status_is_propagated(self):
+        """Cleanup always succeeds and the script's last statement was
+        `kill -9 ... || true`, so a failed batch stage exited 0 and Slurm
+        recorded the job COMPLETED with no output."""
+        for name, mode, script in self._scripts():
+            if mode == "serve":
+                continue
+            with self.subTest(engine=name):
+                self.assertIn("BATCH_RC=$?", script)
+                self.assertEqual(script[-1], "exit ${BATCH_RC:-0}")
+
+    def test_all_generated_scripts_are_valid_bash(self):
+        """Generated shell with nested quotes and a heredoc is where a quoting
+        regression hides while every string assertion stays green."""
+        for name, mode, script in self._scripts():
+            with self.subTest(engine=name, mode=mode):
+                with tempfile.NamedTemporaryFile("w", suffix=".sh") as fh:
+                    fh.write("\n".join(script))
+                    fh.flush()
+                    r = subprocess.run(["bash", "-n", fh.name],
+                                       capture_output=True, text=True)
+                    self.assertEqual(r.returncode, 0, r.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #142.

The generated SLURM script invokes its batch stage as a bare `python3 -c "..."`,
resolved against whatever `PATH` the compute node inherits. The `llmflux` console
script has an absolute shebang and is immune to `PATH` shadowing, so the two
halves disagree: any other interpreter ahead on `PATH` — an activated venv, a
second conda env, a notebook kernel — leaves the CLI working normally while the
batch stage silently picks up a Python with no `llmflux` installed.

Because that stage runs last, the failure surfaces as `ModuleNotFoundError: No
module named 'llmflux'` *after* the model has loaded and the server has passed its
health check, so it reads as a mid-run crash rather than an environment problem.

## Changes

The engines build the script inside the submitting process, so `sys.executable` is
already in scope where the string is assembled. Emit it directly, `shlex.quote`'d.
No new indirection, and nothing left to resolve at job time.

- **Exit with the batch stage's status.** Cleanup always succeeds and the script's
  last statement was `kill -9 … || true`, so a failed batch stage exited 0 and
  Slurm recorded the job COMPLETED with no output. Verified on `main`: exit 0.
- **Dropped `sys.path.append('$PROJECT_ROOT')`.** `PROJECT_ROOT` is the user's cwd
  (`Config.workspace` = `Path.cwd()`); under the `src/` layout it can never contain
  the `llmflux` package, so it was dead code that disguised the missing pin.

9 insertions across the two engines; no change to `runner.py`.

## Verification

Full suite **424 → 428**, same 2 pre-existing `tests.test_cli*` loader errors (they
need `pytest`, absent in my env).

Four tests: the emitted line names `sys.executable`; no `PROJECT_ROOT` hack; the
exit status is propagated; and `bash -n` over all four engine × mode scripts.
Mutation-checked — blanking the interpreter fails
`test_batch_stage_names_the_submitting_interpreter`.

Before/after on a Delta compute node, with the failure condition forced by putting
another conda env's interpreter ahead on `PATH`:

```
hostile PATH -> python3 = /…/conda-env/pytorch-2.12.1-cu130/bin/python3

--- bare python3 (as generated today) ---
ModuleNotFoundError: No module named 'llmflux'

--- pinned ---
import OK -> /sw/llmhub/llmflux/envs/1.0.0/bin/python3
```
